### PR TITLE
sdk changes for better resolution

### DIFF
--- a/.kiro/specs/sdk-cross-project-references/.config.kiro
+++ b/.kiro/specs/sdk-cross-project-references/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "6e5cfb2c-93a4-40c2-80ef-9f03e9ef4223", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/sdk-cross-project-references/design.md
+++ b/.kiro/specs/sdk-cross-project-references/design.md
@@ -1,0 +1,405 @@
+# Design Document: SDK Cross-Project References
+
+## Overview
+
+This feature enables multi-project Fifth solutions to build and run without manual MSBuild workarounds. Two coordinated changes are required:
+
+1. **SDK (`Sdk.targets`)**: Add a `GetTargetPath` target that returns the absolute output assembly path, and update `ResolveFifthProjectReferences` to call `GetTargetPath` on each dependency after building it, populating the `ReferencePath` item group automatically.
+
+2. **Compiler (`LoweredAstToRoslynTranslator.cs`)**: Pass `--reference` paths through to the translator via `TranslatorOptions.AdditionalReferences`, then inspect those assemblies for public static types and generate C# `using static` directives so that cross-project function calls (e.g., `square(7)`) resolve in the emitted C#.
+
+The end result: a project graph like `App (Exe) → MathLib (Library) → CoreLib (Library)` builds with `dotnet build` and runs correctly, with `.5thproj` files containing only standard properties and `ProjectReference` elements.
+
+## Architecture
+
+The feature touches two independent subsystems that cooperate at the `--reference` CLI boundary:
+
+```mermaid
+flowchart TD
+    subgraph SDK ["Fifth.Sdk (Sdk.targets)"]
+        A["ResolveFifthProjectReferences"] -->|"MSBuild Projects=@(ProjectReference) Targets=Build"| B["Build Dependencies"]
+        B --> C["MSBuild Projects=@(ProjectReference) Targets=GetTargetPath"]
+        C -->|"Returns TargetOutputs"| D["Populate ReferencePath ItemGroup"]
+    end
+
+    subgraph Compiler ["Fifth Compiler"]
+        E["FifthCompile Target"] -->|"--reference args from ReferencePath"| F["Program.cs CLI"]
+        F -->|"CompilerOptions.References"| G["Compiler.RoslynEmissionPhase"]
+        G -->|"TranslatorOptions.AdditionalReferences"| H["LoweredAstToRoslynTranslator"]
+        H -->|"Reflect on DLLs"| I["Discover public static types"]
+        I --> J["Generate using static directives"]
+    end
+
+    D --> E
+
+    subgraph GetTargetPath ["GetTargetPath Target (new)"]
+        K["Compute absolute path: MSBuildProjectDirectory + FifthOutputPath"]
+        K --> L["Return via TargetOutputs"]
+    end
+```
+
+### Design Decisions
+
+1. **Absolute path via `$(MSBuildProjectDirectory)\$(FifthOutputPath)`**: MSBuild evaluates `FifthOutputPath` relative to the project being built, but when a referencing project reads the result, relative paths resolve against the wrong directory. Prepending `$(MSBuildProjectDirectory)` ensures correctness regardless of which project queries `GetTargetPath`.
+
+2. **Two-pass MSBuild call in `ResolveFifthProjectReferences`**: First call builds dependencies (`Targets="Build"`), second call queries `GetTargetPath` (`Targets="GetTargetPath"`). This is the standard MSBuild pattern used by the .NET SDK itself. The two calls are necessary because `GetTargetPath` must run after `Build` has produced the output assembly.
+
+3. **Reflection-based type discovery in the translator**: The translator uses `System.Reflection.MetadataLoadContext` (or direct `Assembly.LoadFrom` in a metadata-only context) to inspect referenced DLLs for public static types. This is lightweight and doesn't execute any code from the referenced assemblies.
+
+4. **Extending `IBackendTranslator` vs. passing options through constructor**: Rather than changing the `IBackendTranslator.Translate(AssemblyDef)` interface signature (which would break all implementations), the `LoweredAstToRoslynTranslator` gains a new `Translate(AssemblyDef, TranslatorOptions?)` overload. The `Compiler.RoslynEmissionPhase` method constructs `TranslatorOptions` with `AdditionalReferences` populated from `CompilerOptions.References` and calls the new overload.
+
+5. **`using static` generation follows existing pattern**: The translator already emits `using static Fifth.System.Functional`, `using static Fifth.System.IO`, etc. The same pattern extends naturally to user-provided referenced assemblies — for each public static type discovered, a `using static Namespace.TypeName` directive is added.
+
+
+## Components and Interfaces
+
+### 1. SDK Component: `Sdk.targets`
+
+**File**: `src/Fifth.Sdk/Sdk/Sdk.targets`
+
+#### New Target: `GetTargetPath`
+
+```xml
+<Target Name="GetTargetPath"
+        Outputs="$(_FifthAbsoluteOutputPath)">
+  <PropertyGroup>
+    <_FifthAbsoluteOutputPath Condition="!$([System.IO.Path]::IsPathRooted('$(FifthOutputPath)'))">$(MSBuildProjectDirectory)\$(FifthOutputPath)</_FifthAbsoluteOutputPath>
+    <_FifthAbsoluteOutputPath Condition="$([System.IO.Path]::IsPathRooted('$(FifthOutputPath)'))">$(FifthOutputPath)</_FifthAbsoluteOutputPath>
+  </PropertyGroup>
+</Target>
+```
+
+This target:
+- Checks if `FifthOutputPath` is already absolute using `System.IO.Path.IsPathRooted`
+- If relative, prepends `$(MSBuildProjectDirectory)\` to make it absolute
+- Returns the result via `Outputs` so callers receive it through `TargetOutputs`
+
+#### Modified Target: `ResolveFifthProjectReferences`
+
+```xml
+<Target Name="ResolveFifthProjectReferences" Condition="'@(ProjectReference)' != ''">
+  <!-- Validate references exist -->
+  <ItemGroup>
+    <_FifthMissingProjectReference Include="@(ProjectReference)" Condition="!Exists('%(Identity)')" />
+  </ItemGroup>
+  <Error Condition="'@(_FifthMissingProjectReference)' != ''"
+         Text="Missing project references: @(_FifthMissingProjectReference, ', ')" />
+
+  <!-- Build all dependencies first -->
+  <MSBuild Projects="@(ProjectReference)"
+           Targets="Build"
+           Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework)"
+           BuildInParallel="$(BuildInParallel)" />
+
+  <!-- Query each dependency for its output path -->
+  <MSBuild Projects="@(ProjectReference)"
+           Targets="GetTargetPath"
+           Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework)">
+    <Output TaskParameter="TargetOutputs" ItemName="ReferencePath" />
+  </MSBuild>
+</Target>
+```
+
+### 2. Compiler Component: `Compiler.cs` (RoslynEmissionPhase)
+
+**File**: `src/compiler/Compiler.cs`
+
+The `RoslynEmissionPhase` method is modified to pass reference paths to the translator:
+
+```csharp
+// Create the Roslyn translator
+var translator = new LoweredAstToRoslynTranslator();
+
+// Pass reference paths to the translator via options
+var translatorOptions = new TranslatorOptions
+{
+    AdditionalReferences = options.References?.Where(r => !string.IsNullOrWhiteSpace(r) && File.Exists(r)).ToList()
+};
+
+// Translate the AST to C# sources (new overload)
+var translationResult = translator.Translate(assemblyDef, translatorOptions);
+```
+
+### 3. Translator Component: `LoweredAstToRoslynTranslator.cs`
+
+**File**: `src/compiler/LoweredToRoslyn/LoweredAstToRoslynTranslator.cs`
+
+#### New Overload: `Translate(AssemblyDef, TranslatorOptions?)`
+
+A new public overload that accepts `TranslatorOptions` and passes it through to `TranslateAssembly`:
+
+```csharp
+public TranslationResult Translate(AssemblyDef assembly, TranslatorOptions? options)
+{
+    return TranslateAssembly(assembly, options);
+}
+```
+
+The existing `Translate(AssemblyDef)` overload (from `IBackendTranslator`) continues to call `TranslateAssembly(assembly, null)` for backward compatibility.
+
+#### Modified: `BuildSyntaxTreeFromModule`
+
+After the existing `using static` directives for `Fifth.System.*` types are built, a new block inspects `TranslatorOptions.AdditionalReferences`:
+
+```csharp
+// After existing using directives...
+if (options?.AdditionalReferences != null)
+{
+    foreach (var refPath in options.AdditionalReferences)
+    {
+        var discoveredTypes = DiscoverPublicStaticTypes(refPath);
+        foreach (var fullTypeName in discoveredTypes)
+        {
+            if (usingTracker.Add($"static:{fullTypeName}"))
+            {
+                usingDirectives.Add(
+                    UsingDirective(ParseName(fullTypeName))
+                        .WithStaticKeyword(Token(SyntaxKind.StaticKeyword)));
+            }
+        }
+    }
+}
+```
+
+#### New Method: `DiscoverPublicStaticTypes`
+
+```csharp
+private static IReadOnlyList<string> DiscoverPublicStaticTypes(string assemblyPath)
+```
+
+This method:
+1. Loads the assembly metadata using `MetadataLoadContext` (or `Assembly.ReflectionOnlyLoadFrom` equivalent)
+2. Iterates all exported types
+3. Filters for `public static class` types that contain at least one `public static` method
+4. Returns fully qualified type names (e.g., `"CoreLib.Program"`)
+
+Uses `System.Reflection.MetadataLoadContext` for safe metadata-only inspection without loading assemblies into the execution context.
+
+### 4. `TranslatorOptions` (existing class, no changes needed)
+
+**File**: `src/compiler/LoweredToRoslyn/LoweredAstToRoslynTranslator.cs` (lines 19-23)
+
+```csharp
+public class TranslatorOptions
+{
+    public bool EmitDebugInfo { get; set; } = true;
+    public IReadOnlyList<string>? AdditionalReferences { get; set; }
+}
+```
+
+The `AdditionalReferences` property already exists and is currently unused. This feature activates it.
+
+### Interface Flow
+
+```mermaid
+sequenceDiagram
+    participant MSBuild as MSBuild (Sdk.targets)
+    participant CLI as fifthc CLI (Program.cs)
+    participant Compiler as Compiler.cs
+    participant Translator as LoweredAstToRoslynTranslator
+
+    MSBuild->>MSBuild: ResolveFifthProjectReferences: Build deps
+    MSBuild->>MSBuild: GetTargetPath on each dep → ReferencePath
+    MSBuild->>CLI: fifthc --reference dep1.dll --reference dep2.dll
+    CLI->>Compiler: CompilerOptions { References = [dep1.dll, dep2.dll] }
+    Compiler->>Translator: Translate(assemblyDef, TranslatorOptions { AdditionalReferences = [...] })
+    Translator->>Translator: DiscoverPublicStaticTypes(dep1.dll)
+    Translator->>Translator: DiscoverPublicStaticTypes(dep2.dll)
+    Translator->>Translator: Generate using static directives
+    Translator-->>Compiler: TranslationResult with C# sources
+    Compiler->>Compiler: Roslyn compilation with MetadataReferences
+```
+
+
+## Data Models
+
+### MSBuild Properties and Items
+
+| Property/Item | Scope | Description |
+|---|---|---|
+| `FifthOutputPath` | Per-project | Relative or absolute path to the output assembly (e.g., `bin\Debug\net8.0\CoreLib.dll`) |
+| `_FifthAbsoluteOutputPath` | Internal to `GetTargetPath` | Computed absolute path: `$(MSBuildProjectDirectory)\$(FifthOutputPath)` when relative |
+| `ReferencePath` | Per-project ItemGroup | Populated by `ResolveFifthProjectReferences` with absolute paths to dependency assemblies |
+| `ProjectReference` | Per-project ItemGroup | Standard MSBuild item listing `.5thproj` dependencies |
+
+### Compiler Data Flow
+
+| Data | Type | Source | Destination |
+|---|---|---|---|
+| `--reference` args | `string[]` | MSBuild `FifthCompile` target | `CompilerOptions.References` |
+| `CompilerOptions.References` | `IReadOnlyList<string>?` | CLI parsing in `Program.cs` | `Compiler.RoslynEmissionPhase` |
+| `TranslatorOptions.AdditionalReferences` | `IReadOnlyList<string>?` | `RoslynEmissionPhase` | `LoweredAstToRoslynTranslator` |
+| Discovered type names | `IReadOnlyList<string>` | `DiscoverPublicStaticTypes` | `BuildSyntaxTreeFromModule` using directives |
+
+### Discovered Type Model
+
+The `DiscoverPublicStaticTypes` method returns fully qualified type names as strings. A type qualifies for `using static` generation when:
+
+1. The type is `public` and `static` (i.e., `abstract` + `sealed` in IL terms)
+2. The type contains at least one `public static` method
+3. The type is not a compiler-generated type (no `<` in name, no `CompilerGenerated` attribute)
+
+Example: Given a `CoreLib.dll` containing:
+```csharp
+namespace CoreLib
+{
+    public static class Program
+    {
+        public static int Square(int x) => x * x;
+    }
+}
+```
+
+`DiscoverPublicStaticTypes("CoreLib.dll")` returns `["CoreLib.Program"]`, and the translator emits `using static CoreLib.Program;` in the generated C#.
+
+### Sample `.5thproj` File (Post-Fix)
+
+```xml
+<Project Sdk="Fifth.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <FifthCompilerCommand>fifthc</FifthCompilerCommand>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MathLib\MathLib.5thproj" />
+    <ProjectReference Include="..\CoreLib\CoreLib.5thproj" />
+  </ItemGroup>
+</Project>
+```
+
+No `GetTargetPath` override, no `PopulateFifthReferencePaths`, no `DefaultTargets="Build"`.
+
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Absolute Path Resolution
+
+*For any* project directory string and any relative `FifthOutputPath` string, combining them via `Path.Combine(projectDir, outputPath)` should produce a rooted (absolute) path. Conversely, *for any* already-absolute `FifthOutputPath`, the resolution should return the path unchanged.
+
+**Validates: Requirements 1.2, 1.3, 8.1, 8.2, 8.3**
+
+### Property 2: Public Static Type Discovery Completeness
+
+*For any* valid .NET assembly containing N public static classes that each have at least one public static method, `DiscoverPublicStaticTypes` should return exactly N fully qualified type names, and each returned name should correspond to a type that is public, static, and contains at least one public static method.
+
+**Validates: Requirements 3.1, 3.2, 3.3**
+
+### Property 3: Using Static Generation Correctness
+
+*For any* set of referenced assembly paths where each assembly contains public static types with public static methods, the generated C# compilation unit should contain a `using static` directive for each discovered type, and each directive should use the fully qualified type name (namespace + class name).
+
+**Validates: Requirements 4.1, 4.2**
+
+### Property 4: No Duplicate Using Static Directives
+
+*For any* set of referenced assemblies (including cases where multiple assemblies export types with the same fully qualified name), the generated C# compilation unit should contain at most one `using static` directive per unique fully qualified type name.
+
+**Validates: Requirements 4.3**
+
+### Property 5: Backward Compatibility — No Extra Directives Without References
+
+*For any* Fifth module translated with `AdditionalReferences` set to null or empty, the set of `using static` directives in the generated C# should be identical to the set produced by the current translator (i.e., only `Fifth.System.Functional`, `Fifth.System.List`, `Fifth.System.IO`, `Fifth.System.Math`, and any namespace-import-derived directives).
+
+**Validates: Requirements 4.4, 9.2, 9.3**
+
+## Error Handling
+
+### SDK Error Handling
+
+| Condition | Behavior |
+|---|---|
+| `ProjectReference` points to non-existent `.5thproj` file | `ResolveFifthProjectReferences` emits MSBuild error: "Missing project references: ..." (existing behavior, unchanged) |
+| Dependency project build fails | MSBuild propagates the build failure; `GetTargetPath` is never called (standard MSBuild behavior) |
+| `FifthOutputPath` is empty or unset | `GetTargetPath` returns empty string; `FifthCompile` will fail at compilation time with existing validation |
+
+### Compiler Error Handling
+
+| Condition | Behavior |
+|---|---|
+| `--reference` path does not exist | `DiscoverPublicStaticTypes` logs a warning diagnostic and returns empty list; compilation continues (Req 3.4) |
+| `--reference` path is not a valid .NET assembly | `DiscoverPublicStaticTypes` catches the exception, logs a warning diagnostic, and returns empty list |
+| `MetadataLoadContext` fails to load assembly | Same as above — warning + empty list |
+| Referenced assembly has no public static types | No additional `using static` directives generated; no warning (this is normal for assemblies that only export instance types) |
+| Duplicate type names across assemblies | The `usingTracker` `HashSet` prevents duplicate directives (existing dedup mechanism in `BuildSyntaxTreeFromModule`) |
+
+### Diagnostic Messages
+
+- Warning for missing reference: `"Referenced assembly not found: {path}"` (code: `REF001`)
+- Warning for unloadable reference: `"Could not load referenced assembly: {path}: {exception.Message}"` (code: `REF002`)
+
+## Testing Strategy
+
+### Unit Tests (xUnit + FluentAssertions)
+
+Unit tests verify specific examples and edge cases:
+
+1. **`DiscoverPublicStaticTypes` tests**:
+   - Assembly with one public static class → returns that class name
+   - Assembly with no public static classes → returns empty list
+   - Assembly with mix of static and non-static classes → returns only static ones
+   - Non-existent path → returns empty list + warning diagnostic
+   - Invalid DLL file → returns empty list + warning diagnostic
+
+2. **`BuildSyntaxTreeFromModule` using directive tests**:
+   - Module with no additional references → default using directives only
+   - Module with one reference containing one public static type → adds one `using static`
+   - Module with multiple references → adds `using static` for each discovered type
+   - Duplicate type across references → only one `using static` emitted
+
+3. **SDK integration tests** (existing `test/fifth-sdk-tests/`):
+   - Build a multi-project sample and verify exit code 0
+   - Verify `ReferencePath` is populated after `ResolveFifthProjectReferences`
+   - Verify clean `.5thproj` files work without workarounds
+
+4. **End-to-end tests**:
+   - Build and run `FullProjectExample` sample
+   - Verify `square(7)` returns 49 and `add(49, 3)` returns 52
+
+### Property-Based Tests (FsCheck + xUnit)
+
+The project should add `FsCheck` and `FsCheck.Xunit` NuGet packages to the relevant test project (`test/runtime-integration-tests/` or `test/ast-tests/`).
+
+Each property test runs a minimum of 100 iterations.
+
+Each property test is tagged with a comment referencing the design property:
+
+```csharp
+// Feature: sdk-cross-project-references, Property 1: Absolute Path Resolution
+```
+
+**Property test implementations**:
+
+1. **Property 1: Absolute Path Resolution**
+   - Generate random directory paths and random relative file paths
+   - Verify that combining them always produces a rooted path
+   - Generate random absolute paths and verify they are returned unchanged
+
+2. **Property 2: Public Static Type Discovery Completeness**
+   - Generate test assemblies (via Roslyn in-memory compilation) with random numbers of public static classes, each with random numbers of public static methods, plus non-static classes as noise
+   - Verify that `DiscoverPublicStaticTypes` returns exactly the public static types with methods
+
+3. **Property 3: Using Static Generation Correctness**
+   - Generate random sets of type names, create test assemblies containing those types
+   - Translate a minimal module with those assemblies as references
+   - Verify the generated C# contains `using static` for each type with the correct fully qualified name
+
+4. **Property 4: No Duplicate Using Static Directives**
+   - Generate random sets of type names including intentional duplicates across multiple assemblies
+   - Translate a minimal module with those assemblies as references
+   - Verify the count of `using static` directives equals the count of distinct type names
+
+5. **Property 5: Backward Compatibility**
+   - Generate random Fifth modules (varying numbers of functions, classes, namespaces)
+   - Translate with `AdditionalReferences = null`
+   - Verify the using directive set matches the known default set exactly
+
+### Test Configuration
+
+- Property-based testing library: **FsCheck 2.x** with **FsCheck.Xunit** integration
+- Minimum iterations per property: **100**
+- Test projects: `test/ast-tests/` for translator unit tests, `test/runtime-integration-tests/` for integration tests
+- Each property test references its design document property via comment tag
+

--- a/.kiro/specs/sdk-cross-project-references/requirements.md
+++ b/.kiro/specs/sdk-cross-project-references/requirements.md
@@ -1,0 +1,114 @@
+# Requirements Document
+
+## Introduction
+
+This feature fixes cross-project references in the Fifth language SDK and compiler so that multi-project solutions (e.g., `samples/FullProjectExample/`) compile out of the box without requiring MSBuild target overrides in individual `.5thproj` files. Two systems must be fixed: (1) the SDK's MSBuild plumbing in `Sdk.targets` must populate `ReferencePath` after building dependencies, and (2) the compiler's Roslyn backend must generate the necessary C# `using static` directives for public static types discovered in referenced assemblies, so that bare Fifth function calls like `square(7)` resolve correctly in the emitted C# code. Fifth itself has no `using static` syntax — this is purely an internal code generation concern. After both fixes, a project graph like `App (Exe) → MathLib (Library) → CoreLib (Library)` builds and runs with minimal `.5thproj` files and no workarounds.
+
+## Glossary
+
+- **Fifth_Sdk**: The MSBuild SDK (`Fifth.Sdk`) that provides build targets for `.5thproj` files, defined in `src/Fifth.Sdk/Sdk/Sdk.targets`.
+- **Fifth_Compiler**: The Fifth language compiler (`fifthc`), whose Roslyn backend translates Fifth AST to C# and compiles it via Roslyn.
+- **Roslyn_Backend**: The code generation phase in `src/compiler/LoweredToRoslyn/LoweredAstToRoslynTranslator.cs` that produces C# syntax trees from the lowered Fifth AST.
+- **Sdk_Targets**: The MSBuild targets file at `src/Fifth.Sdk/Sdk/Sdk.targets` that orchestrates Fifth project builds.
+- **ReferencePath**: An MSBuild item group populated with absolute paths to dependency assemblies; consumed by the `FifthCompile` target to construct `--reference` arguments for the compiler.
+- **GetTargetPath**: An MSBuild target that returns the absolute output assembly path of a project, used by referencing projects to discover dependency outputs.
+- **ResolveFifthProjectReferences**: An MSBuild target in Sdk_Targets that builds all `ProjectReference` dependencies before the current project compiles.
+- **FifthOutputPath**: An MSBuild property holding the output assembly path for a Fifth project; defaults to a relative path.
+- **Referenced_Assembly**: A `.dll` file produced by a dependency project and passed to the compiler via `--reference`.
+- **Cross_Project_Function_Call**: A call in Fifth source code to a function defined in a different project (e.g., calling `square(7)` from CoreLib in App's `main.5th`). Fifth has no import or `using` syntax — cross-project resolution is handled entirely by the compiler's Roslyn backend during C# code generation.
+
+## Requirements
+
+### Requirement 1: GetTargetPath Target in SDK
+
+**User Story:** As a Fifth developer with multi-project solutions, I want the SDK to provide a `GetTargetPath` target that returns the absolute output path of a project, so that referencing projects can discover dependency assembly locations without manual MSBuild overrides.
+
+#### Acceptance Criteria
+
+1. THE Sdk_Targets SHALL define a `GetTargetPath` target that returns the absolute output assembly path of the current project.
+2. THE GetTargetPath target SHALL prepend `$(MSBuildProjectDirectory)` to `$(FifthOutputPath)` when FifthOutputPath is a relative path, so that the returned path is correct regardless of which project queries it.
+3. WHEN a referencing project invokes `GetTargetPath` on a dependency, THE GetTargetPath target SHALL return a path that resolves to the dependency's output assembly, not a path relative to the referencing project's directory.
+
+### Requirement 2: Automatic ReferencePath Population in SDK
+
+**User Story:** As a Fifth developer, I want the SDK to automatically populate `ReferencePath` after building dependencies, so that the compiler receives `--reference` arguments without requiring a `PopulateFifthReferencePaths` target override in each `.5thproj` file.
+
+#### Acceptance Criteria
+
+1. THE ResolveFifthProjectReferences target SHALL invoke `GetTargetPath` on each `ProjectReference` dependency after building the dependencies.
+2. THE ResolveFifthProjectReferences target SHALL populate the `ReferencePath` item group with the output paths returned by `GetTargetPath`.
+3. WHEN a Fifth project has one or more ProjectReference dependencies, THE FifthCompile target SHALL receive non-empty `--reference` arguments corresponding to each dependency's output assembly.
+4. WHEN a Fifth project has no ProjectReference dependencies, THE ResolveFifthProjectReferences target SHALL leave `ReferencePath` empty.
+
+### Requirement 3: Compiler Discovers Public Static Types in Referenced Assemblies
+
+**User Story:** As a Fifth developer, I want the compiler's Roslyn backend to inspect referenced assemblies for public static types, so that functions defined in dependency projects are available for cross-project calls without any Fifth-side import syntax.
+
+#### Acceptance Criteria
+
+1. WHEN `--reference` paths are provided to the Fifth_Compiler, THE Roslyn_Backend SHALL load metadata from each Referenced_Assembly.
+2. THE Roslyn_Backend SHALL discover all public static types in each Referenced_Assembly.
+3. THE Roslyn_Backend SHALL discover all public static methods within each discovered public static type.
+4. IF a Referenced_Assembly path does not exist or cannot be loaded, THEN THE Fifth_Compiler SHALL emit a warning diagnostic and continue compilation.
+
+### Requirement 4: Compiler Generates C# Using Static Directives for Referenced Types
+
+**User Story:** As a Fifth developer, I want the compiler's Roslyn backend to automatically generate C# `using static` directives for public static types in referenced assemblies, so that cross-project function calls in my Fifth code (e.g., `square(7)`) resolve correctly in the emitted C# without any Fifth-side import syntax.
+
+#### Acceptance Criteria
+
+1. WHEN the Roslyn_Backend discovers public static types with public static methods in a Referenced_Assembly, THE Roslyn_Backend SHALL generate a C# `using static` directive for each such type in the emitted C# compilation unit.
+2. THE Roslyn_Backend SHALL generate C# `using static` directives that use the fully qualified type name (namespace and class name).
+3. THE Roslyn_Backend SHALL NOT generate duplicate C# `using static` directives for the same type.
+4. WHEN no `--reference` paths are provided, THE Roslyn_Backend SHALL not generate any additional C# `using static` directives beyond the existing defaults (e.g., `Fifth.System.Functional`, `Fifth.System.IO`, etc.).
+
+### Requirement 5: Clean .5thproj Files Without Workarounds
+
+**User Story:** As a Fifth developer, I want my `.5thproj` files to contain only standard properties and ProjectReference elements, so that I do not need to add MSBuild target overrides to make cross-project references work.
+
+#### Acceptance Criteria
+
+1. WHEN the SDK fixes are applied, THE sample `.5thproj` files SHALL NOT require a `GetTargetPath` target override.
+2. WHEN the SDK fixes are applied, THE sample `.5thproj` files SHALL NOT require a `PopulateFifthReferencePaths` target.
+3. WHEN the SDK fixes are applied, THE sample `.5thproj` files SHALL NOT require `DefaultTargets="Build"` to function correctly.
+4. Each `.5thproj` file SHALL contain only `<PropertyGroup>` (with OutputType, TargetFramework, FifthCompilerCommand) and `<ItemGroup>` (with ProjectReference elements) as needed.
+
+### Requirement 6: End-to-End Multi-Project Build
+
+**User Story:** As a Fifth developer, I want `dotnet build` on a multi-project Fifth solution to succeed without errors, so that I can develop multi-project solutions with the same ease as single-project builds.
+
+#### Acceptance Criteria
+
+1. WHEN `dotnet build src/App/App.5thproj` is executed in the FullProjectExample sample, THE build SHALL succeed without errors.
+2. WHEN `dotnet build FullProjectExample.slnx` is executed, THE build SHALL succeed without errors for all projects in the solution.
+3. WHEN `dotnet run --project src/App/App.5thproj` is executed, THE application SHALL execute and produce correct results from cross-project function calls: `square(7)` returns 49 and `add(49, 3)` returns 52, where `square` is defined in `core.5th` and `add` is defined in `math.5th`.
+
+### Requirement 7: Transitive Dependency Resolution
+
+**User Story:** As a Fifth developer, I want transitive project dependencies to resolve correctly, so that a project referencing a library that itself references another library can call functions from both.
+
+#### Acceptance Criteria
+
+1. WHEN App references MathLib and MathLib references CoreLib, THE build system SHALL build CoreLib before MathLib and MathLib before App.
+2. WHEN App's `main.5th` calls `square(7)` (defined in CoreLib's `core.5th`) and `add(sq, 3)` (defined in MathLib's `math.5th`), THE Fifth_Compiler SHALL resolve both function calls in App's compilation without any import syntax in the Fifth source.
+3. THE ReferencePath for App SHALL include the output assemblies of both MathLib and CoreLib.
+
+### Requirement 8: Absolute Path Resolution for FifthOutputPath
+
+**User Story:** As a Fifth developer, I want the SDK to always return absolute paths for project outputs, so that cross-project path resolution is correct regardless of directory structure.
+
+#### Acceptance Criteria
+
+1. THE GetTargetPath target SHALL return an absolute path by combining `$(MSBuildProjectDirectory)` with `$(FifthOutputPath)`.
+2. WHEN FifthOutputPath is a relative path (e.g., `bin/Debug/net8.0/CoreLib.dll`), THE GetTargetPath target SHALL resolve the path relative to the project's own directory, not the caller's directory.
+3. WHEN FifthOutputPath is already an absolute path, THE GetTargetPath target SHALL return the path unchanged.
+
+### Requirement 9: Backward Compatibility
+
+**User Story:** As a Fifth developer with existing single-project setups, I want the SDK and compiler changes to be backward compatible, so that projects without ProjectReference dependencies continue to build correctly.
+
+#### Acceptance Criteria
+
+1. WHEN a Fifth project has no ProjectReference elements, THE build SHALL succeed with the same behavior as before the changes.
+2. WHEN no `--reference` arguments are passed to the Fifth_Compiler, THE Roslyn_Backend SHALL produce identical C# output to the current behavior (no additional `using static` directives in the generated C#).
+3. THE changes SHALL NOT alter the generated C# code for projects that do not use cross-project references.

--- a/.kiro/specs/sdk-cross-project-references/tasks.md
+++ b/.kiro/specs/sdk-cross-project-references/tasks.md
@@ -1,0 +1,120 @@
+# Implementation Plan: SDK Cross-Project References
+
+## Overview
+
+Two coordinated changes enable multi-project Fifth solutions to build and run without MSBuild workarounds: (1) SDK `Sdk.targets` gets a `GetTargetPath` target and updated `ResolveFifthProjectReferences` to auto-populate `ReferencePath`, and (2) the compiler's Roslyn translator discovers public static types in referenced assemblies and generates `using static` directives. Implementation language is C# (matching the existing codebase).
+
+## Tasks
+
+- [x] 1. Add `GetTargetPath` target and update `ResolveFifthProjectReferences` in SDK
+  - [x] 1.1 Add `GetTargetPath` target to `src/Fifth.Sdk/Sdk/Sdk.targets`
+    - Add a new `<Target Name="GetTargetPath" Outputs="$(_FifthAbsoluteOutputPath)">` after the existing property groups
+    - Compute `_FifthAbsoluteOutputPath` using `System.IO.Path.IsPathRooted` check on `$(FifthOutputPath)`
+    - When relative, prepend `$(MSBuildProjectDirectory)\$(FifthOutputPath)`; when absolute, use `$(FifthOutputPath)` unchanged
+    - _Requirements: 1.1, 1.2, 1.3, 8.1, 8.2, 8.3_
+
+  - [x] 1.2 Update `ResolveFifthProjectReferences` target in `src/Fifth.Sdk/Sdk/Sdk.targets`
+    - After the existing `<MSBuild Projects="@(ProjectReference)" Targets="Build" .../>` call, add a second `<MSBuild>` call with `Targets="GetTargetPath"`
+    - Add `<Output TaskParameter="TargetOutputs" ItemName="ReferencePath" />` to populate the `ReferencePath` item group
+    - Pass same `Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework)"` to the second call
+    - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+  - [x] 1.3 Write property test for absolute path resolution (Property 1)
+    - **Property 1: Absolute Path Resolution**
+    - Generate random directory paths and random relative file paths; verify combining them always produces a rooted path
+    - Generate random absolute paths and verify they are returned unchanged
+    - Add FsCheck and FsCheck.Xunit packages to `test/ast-tests/ast_tests.csproj`
+    - Create test class `CrossProjectReferencePropertyTests.cs` in `test/ast-tests/`
+    - **Validates: Requirements 1.2, 1.3, 8.1, 8.2, 8.3**
+
+- [x] 2. Checkpoint - Verify SDK changes
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 3. Implement `DiscoverPublicStaticTypes` in the Roslyn translator
+  - [x] 3.1 Add `DiscoverPublicStaticTypes` method to `src/compiler/LoweredToRoslyn/LoweredAstToRoslynTranslator.cs`
+    - Add `private static IReadOnlyList<string> DiscoverPublicStaticTypes(string assemblyPath)` method
+    - Use `System.Reflection.MetadataLoadContext` to load assembly metadata without executing code
+    - Iterate exported types, filter for public static classes (`abstract` + `sealed` in IL) with at least one public static method
+    - Exclude compiler-generated types (names containing `<`, types with `CompilerGenerated` attribute)
+    - Return fully qualified type names (e.g., `"CoreLib.Program"`)
+    - Handle missing/invalid assembly paths gracefully: log warning diagnostic, return empty list
+    - _Requirements: 3.1, 3.2, 3.3, 3.4_
+
+  - [x] 3.2 Write property test for public static type discovery (Property 2)
+    - **Property 2: Public Static Type Discovery Completeness**
+    - Generate test assemblies via Roslyn in-memory compilation with random numbers of public static classes (each with random public static methods) plus non-static classes as noise
+    - Verify `DiscoverPublicStaticTypes` returns exactly the public static types with methods
+    - Add test to `CrossProjectReferencePropertyTests.cs` in `test/ast-tests/`
+    - **Validates: Requirements 3.1, 3.2, 3.3**
+
+- [x] 4. Wire translator options and generate `using static` directives
+  - [x] 4.1 Add `Translate(AssemblyDef, TranslatorOptions?)` overload to `LoweredAstToRoslynTranslator`
+    - Add new public method `Translate(AssemblyDef assembly, TranslatorOptions? options)` that calls `TranslateAssembly(assembly, options)`
+    - Update existing `Translate(AssemblyDef)` to call `TranslateAssembly(assembly, null)` (should already be the case)
+    - Thread `TranslatorOptions` parameter through `TranslateAssembly` and `BuildSyntaxTreeFromModule`
+    - _Requirements: 3.1, 4.1_
+
+  - [x] 4.2 Generate `using static` directives from additional references in `BuildSyntaxTreeFromModule`
+    - After the existing `using static` directives and namespace import loop, add a new block
+    - Iterate `options?.AdditionalReferences`, call `DiscoverPublicStaticTypes` for each
+    - For each discovered type, add `using static FullyQualifiedTypeName` directive using existing `usingTracker` for dedup
+    - Use `UsingDirective(ParseName(fullTypeName)).WithStaticKeyword(Token(SyntaxKind.StaticKeyword))` matching existing pattern
+    - _Requirements: 4.1, 4.2, 4.3, 4.4_
+
+  - [x] 4.3 Update `RoslynEmissionPhase` in `src/compiler/Compiler.cs` to pass references to translator
+    - Construct `TranslatorOptions` with `AdditionalReferences` populated from `options.References` (filter for non-empty, existing file paths)
+    - Call `translator.Translate(assemblyDef, translatorOptions)` instead of `translator.Translate(assemblyDef)`
+    - _Requirements: 3.1, 4.1_
+
+  - [x] 4.4 Write property test for using static generation correctness (Property 3)
+    - **Property 3: Using Static Generation Correctness**
+    - Generate random sets of type names, create test assemblies containing those types
+    - Translate a minimal module with those assemblies as references
+    - Verify the generated C# contains `using static` for each type with the correct fully qualified name
+    - Add test to `CrossProjectReferencePropertyTests.cs` in `test/ast-tests/`
+    - **Validates: Requirements 4.1, 4.2**
+
+  - [x] 4.5 Write property test for no duplicate using static directives (Property 4)
+    - **Property 4: No Duplicate Using Static Directives**
+    - Generate random sets of type names including intentional duplicates across multiple assemblies
+    - Translate a minimal module with those assemblies as references
+    - Verify the count of `using static` directives equals the count of distinct type names
+    - Add test to `CrossProjectReferencePropertyTests.cs` in `test/ast-tests/`
+    - **Validates: Requirements 4.3**
+
+  - [x] 4.6 Write property test for backward compatibility (Property 5)
+    - **Property 5: Backward Compatibility — No Extra Directives Without References**
+    - Generate random Fifth modules (varying numbers of functions)
+    - Translate with `AdditionalReferences = null`
+    - Verify the using directive set matches the known default set exactly (no additional `using static` directives)
+    - Add test to `CrossProjectReferencePropertyTests.cs` in `test/ast-tests/`
+    - **Validates: Requirements 4.4, 9.2, 9.3**
+
+- [x] 5. Checkpoint - Verify compiler changes
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 6. Clean up sample projects and wire end-to-end
+  - [x] 6.1 Clean up sample `.5thproj` files in `samples/FullProjectExample/`
+    - Remove any `GetTargetPath` target overrides from `.5thproj` files
+    - Remove any `PopulateFifthReferencePaths` targets from `.5thproj` files
+    - Remove any `DefaultTargets="Build"` attributes from `.5thproj` files
+    - Ensure each `.5thproj` contains only `<PropertyGroup>` (OutputType, TargetFramework, FifthCompilerCommand) and `<ItemGroup>` (ProjectReference) as needed
+    - _Requirements: 5.1, 5.2, 5.3, 5.4_
+
+  - [x] 6.2 Write unit tests for translator with references
+    - Test `DiscoverPublicStaticTypes` with: one public static class → returns that class name; no public static classes → empty list; mix of static and non-static → only static ones; non-existent path → empty list; invalid DLL → empty list
+    - Test `BuildSyntaxTreeFromModule` using directives: no additional references → default directives only; one reference with one public static type → adds one `using static`; multiple references → adds `using static` for each; duplicate type across references → only one emitted
+    - Add tests to `test/ast-tests/CrossProjectReferenceTests.cs`
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3, 4.4, 9.2, 9.3_
+
+- [x] 7. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Property tests use FsCheck + FsCheck.Xunit and should be added to `test/ast-tests/`
+- The `TranslatorOptions` class already has `AdditionalReferences` property — no new class needed
+- Build commands are long-running (~60-70s); never cancel them (see AGENTS.md)
+- Checkpoints ensure incremental validation between SDK and compiler changes

--- a/samples/FullProjectExample/FullProjectExample.slnx
+++ b/samples/FullProjectExample/FullProjectExample.slnx
@@ -1,0 +1,5 @@
+<Solution>
+  <Project Path="src\App\App.5thproj" Type="{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}" />
+  <Project Path="src\MathLib\MathLib.5thproj" Type="{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}" />
+  <Project Path="src\CoreLib\CoreLib.5thproj" Type="{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}" />
+</Solution>

--- a/samples/FullProjectExample/src/App/App.5thproj
+++ b/samples/FullProjectExample/src/App/App.5thproj
@@ -1,0 +1,11 @@
+<Project Sdk="Fifth.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <FifthCompilerCommand>fifthc</FifthCompilerCommand>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MathLib\MathLib.5thproj" />
+    <ProjectReference Include="..\CoreLib\CoreLib.5thproj" />
+  </ItemGroup>
+</Project>

--- a/samples/FullProjectExample/src/App/main.5th
+++ b/samples/FullProjectExample/src/App/main.5th
@@ -1,0 +1,11 @@
+// App: demonstrates cross-project function calls
+// square is defined in CoreLib, add is defined in MathLib
+main(): int {
+    sq: int;
+    sq = square(7);
+    result: int;
+    result = add(sq, 3);
+    std.print($"square(7) = {sq}");
+    std.print($"add(49, 3) = {result}");
+    return 0;
+}

--- a/samples/FullProjectExample/src/CoreLib/CoreLib.5thproj
+++ b/samples/FullProjectExample/src/CoreLib/CoreLib.5thproj
@@ -1,0 +1,7 @@
+<Project Sdk="Fifth.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <FifthCompilerCommand>fifthc</FifthCompilerCommand>
+  </PropertyGroup>
+</Project>

--- a/samples/FullProjectExample/src/CoreLib/core.5th
+++ b/samples/FullProjectExample/src/CoreLib/core.5th
@@ -1,0 +1,4 @@
+// CoreLib: provides the square function
+square(x: int): int {
+    return x * x;
+}

--- a/samples/FullProjectExample/src/MathLib/MathLib.5thproj
+++ b/samples/FullProjectExample/src/MathLib/MathLib.5thproj
@@ -1,0 +1,10 @@
+<Project Sdk="Fifth.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <FifthCompilerCommand>fifthc</FifthCompilerCommand>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CoreLib\CoreLib.5thproj" />
+  </ItemGroup>
+</Project>

--- a/samples/FullProjectExample/src/MathLib/math.5th
+++ b/samples/FullProjectExample/src/MathLib/math.5th
@@ -1,0 +1,4 @@
+// MathLib: provides the add function
+add(a: int, b: int): int {
+    return a + b;
+}

--- a/src/Fifth.Sdk/Sdk/Sdk.targets
+++ b/src/Fifth.Sdk/Sdk/Sdk.targets
@@ -22,6 +22,14 @@
     <UpToDateCheckOutput Include="$(FifthOutputPath)" Condition="'$(FifthOutputPath)' != ''" />
   </ItemGroup>
 
+  <Target Name="GetTargetPath"
+          Outputs="$(_FifthAbsoluteOutputPath)">
+    <PropertyGroup>
+      <_FifthAbsoluteOutputPath Condition="!$([System.IO.Path]::IsPathRooted('$(FifthOutputPath)'))">$(MSBuildProjectDirectory)\$(FifthOutputPath)</_FifthAbsoluteOutputPath>
+      <_FifthAbsoluteOutputPath Condition="$([System.IO.Path]::IsPathRooted('$(FifthOutputPath)'))">$(FifthOutputPath)</_FifthAbsoluteOutputPath>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="FifthCompile" 
           DependsOnTargets="ResolveFifthCompilerPath;ResolveFifthProjectReferences;ValidatePackageReferences;ValidateFifthTargetFrameworks"
           Inputs="@(FifthSource);$(FifthSourceManifestPath);$(FifthCompilerPath);@(ReferencePath)"
@@ -107,6 +115,13 @@
              Targets="Build"
              Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework)"
              BuildInParallel="$(BuildInParallel)" />
+
+    <!-- Query each dependency for its output path -->
+    <MSBuild Projects="@(ProjectReference)"
+             Targets="GetTargetPath"
+             Properties="Configuration=$(Configuration);TargetFramework=$(TargetFramework)">
+      <Output TaskParameter="TargetOutputs" ItemName="ReferencePath" />
+    </MSBuild>
   </Target>
 
   <Target Name="ValidatePackageReferences" Condition="'@(PackageReference)' != ''">

--- a/src/Fifth.Sdk/packages.lock.json
+++ b/src/Fifth.Sdk/packages.lock.json
@@ -695,6 +695,15 @@
           "System.Collections.Immutable": "8.0.0"
         }
       },
+      "System.Reflection.MetadataLoadContext": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "SZxrQ4sQYnIcdwiO3G/lHZopbPYQ2lW0ioT4JezgccWUrKaKbHLJbAGZaDfkYjWcta1pWssAo3MOXLsR0ie4tQ==",
+        "dependencies": {
+          "System.Collections.Immutable": "8.0.0",
+          "System.Reflection.Metadata": "8.0.0"
+        }
+      },
       "System.Reflection.Primitives": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -990,6 +999,7 @@
           "Fifth.System": "[1.0.0, )",
           "Microsoft.CodeAnalysis.CSharp": "[4.11.0, )",
           "System.CommandLine": "[2.0.0-beta4.22272.1, )",
+          "System.Reflection.MetadataLoadContext": "[8.0.0, )",
           "ast_generated": "[1.0.0, )",
           "ast_model": "[1.0.0, )",
           "parser": "[1.0.0, )"

--- a/src/compiler/Compiler.cs
+++ b/src/compiler/Compiler.cs
@@ -308,6 +308,7 @@ Examples:
                     {
                         name = FrameworkReferenceSettings.DefaultFrameworkName,
                         version = FrameworkReferenceSettings.GetFrameworkVersion(normalizedTfm)
+                    }
                 }
             };
 
@@ -438,8 +439,16 @@ Examples:
             // Create the Roslyn translator
             var translator = new LoweredAstToRoslynTranslator();
 
+            // Pass reference paths to the translator via options
+            var translatorOptions = new TranslatorOptions
+            {
+                AdditionalReferences = options.References?
+                    .Where(r => !string.IsNullOrWhiteSpace(r) && File.Exists(r))
+                    .ToList()
+            };
+
             // Translate the AST to C# sources
-            var translationResult = translator.Translate(assemblyDef);
+            var translationResult = translator.Translate(assemblyDef, translatorOptions);
 
             // Check for translation diagnostics
             if (translationResult.Diagnostics != null && translationResult.Diagnostics.Any())

--- a/src/compiler/LoweredToRoslyn/LoweredAstToRoslynTranslator.cs
+++ b/src/compiler/LoweredToRoslyn/LoweredAstToRoslynTranslator.cs
@@ -120,6 +120,14 @@ public class LoweredAstToRoslynTranslator : IBackendTranslator
     }
 
     /// <summary>
+    /// Translate AssemblyDef with translator options (e.g., additional references)
+    /// </summary>
+    public TranslationResult Translate(AssemblyDef assembly, TranslatorOptions? options)
+    {
+        return TranslateAssembly(assembly, options);
+    }
+
+    /// <summary>
     /// Translate LoweredAstModule (for backward compatibility with tests)
     /// </summary>
     public TranslationResult Translate(LoweredAstModule module, TranslatorOptions? options = null)
@@ -179,7 +187,7 @@ public class LoweredAstToRoslynTranslator : IBackendTranslator
 
                 var emitStubMain = !hasModuleMain && !hasAnyMain && isSingleModule;
 
-                var syntaxTree = BuildSyntaxTreeFromModule(module, mapping, emitStubMain);
+                var syntaxTree = BuildSyntaxTreeFromModule(module, mapping, emitStubMain, options);
                 var sourceText = syntaxTree.GetText().ToString();
                 sources.Add(sourceText);
             }
@@ -196,7 +204,7 @@ public class LoweredAstToRoslynTranslator : IBackendTranslator
         return new TranslationResult(sources, mapping, diagnostics);
     }
 
-    private SyntaxTree BuildSyntaxTreeFromModule(ModuleDef module, MappingTable mapping, bool emitStubMain)
+    private SyntaxTree BuildSyntaxTreeFromModule(ModuleDef module, MappingTable mapping, bool emitStubMain, TranslatorOptions? options = null)
     {
         _moduleLevelFunctionNames = module.Functions
             .OfType<FunctionDef>()
@@ -238,6 +246,24 @@ public class LoweredAstToRoslynTranslator : IBackendTranslator
                 usingDirectives.Add(
                     UsingDirective(ParseName($"{importNamespace}.Program"))
                         .WithStaticKeyword(Token(SyntaxKind.StaticKeyword)));
+            }
+        }
+
+        // Generate using static directives for public static types in referenced assemblies
+        if (options?.AdditionalReferences != null)
+        {
+            foreach (var refPath in options.AdditionalReferences)
+            {
+                var discoveredTypes = DiscoverPublicStaticTypes(refPath);
+                foreach (var fullTypeName in discoveredTypes)
+                {
+                    if (usingTracker.Add($"static:{fullTypeName}"))
+                    {
+                        usingDirectives.Add(
+                            UsingDirective(ParseName(fullTypeName))
+                                .WithStaticKeyword(Token(SyntaxKind.StaticKeyword)));
+                    }
+                }
             }
         }
 
@@ -2573,5 +2599,77 @@ public class LoweredAstToRoslynTranslator : IBackendTranslator
         return value
             .Replace("\\", "\\\\")
             .Replace("\"", "\\\"");
+    }
+
+    /// <summary>
+    /// Discovers public static types in a referenced assembly that contain at least one
+    /// public static method. Uses MetadataLoadContext for safe metadata-only inspection
+    /// without loading assemblies into the execution context.
+    /// </summary>
+    /// <param name="assemblyPath">Absolute path to the referenced assembly (.dll).</param>
+    /// <returns>Fully qualified type names (e.g., "CoreLib.Program") for each qualifying type.</returns>
+    internal static IReadOnlyList<string> DiscoverPublicStaticTypes(string assemblyPath)
+    {
+        if (string.IsNullOrWhiteSpace(assemblyPath) || !File.Exists(assemblyPath))
+        {
+            // REF001: Referenced assembly not found
+            System.Console.Error.WriteLine($"Warning REF001: Referenced assembly not found: {assemblyPath}");
+            return Array.Empty<string>();
+        }
+
+        try
+        {
+            // Build the set of assembly paths for the resolver: the target assembly
+            // plus the runtime assemblies so that core types (System.Object, etc.) resolve.
+            var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+            var runtimeAssemblies = Directory.GetFiles(runtimeDir, "*.dll");
+
+            var resolverPaths = new List<string>(runtimeAssemblies) { assemblyPath };
+            var resolver = new PathAssemblyResolver(resolverPaths);
+
+            using var mlc = new System.Reflection.MetadataLoadContext(resolver);
+            var assembly = mlc.LoadFromAssemblyPath(assemblyPath);
+
+            var result = new List<string>();
+
+            foreach (var type in assembly.GetExportedTypes())
+            {
+                // Skip compiler-generated types (names containing '<' or with CompilerGenerated attribute)
+                if (type.Name.Contains('<'))
+                {
+                    continue;
+                }
+
+                var hasCompilerGenerated = type.CustomAttributes.Any(a =>
+                    a.AttributeType.Name == "CompilerGeneratedAttribute");
+                if (hasCompilerGenerated)
+                {
+                    continue;
+                }
+
+                // A public static class in IL is abstract + sealed
+                if (!type.IsAbstract || !type.IsSealed)
+                {
+                    continue;
+                }
+
+                // Must have at least one public static method
+                var hasPublicStaticMethod = type.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                    .Any();
+
+                if (hasPublicStaticMethod)
+                {
+                    result.Add(type.FullName ?? type.Name);
+                }
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            // REF002: Could not load referenced assembly
+            System.Console.Error.WriteLine($"Warning REF002: Could not load referenced assembly: {assemblyPath}: {ex.Message}");
+            return Array.Empty<string>();
+        }
     }
 }

--- a/src/compiler/compiler.csproj
+++ b/src/compiler/compiler.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/compiler/packages.lock.json
+++ b/src/compiler/packages.lock.json
@@ -20,6 +20,16 @@
         "resolved": "2.0.0-beta4.22272.1",
         "contentHash": "1uqED/q2H0kKoLJ4+hI2iPSBSEdTuhfCYADeJrAqERmiGQ2NNacYKRNEQ+gFbU4glgVyK8rxI+ZOe1onEtr/Pg=="
       },
+      "System.Reflection.MetadataLoadContext": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "SZxrQ4sQYnIcdwiO3G/lHZopbPYQ2lW0ioT4JezgccWUrKaKbHLJbAGZaDfkYjWcta1pWssAo3MOXLsR0ie4tQ==",
+        "dependencies": {
+          "System.Collections.Immutable": "8.0.0",
+          "System.Reflection.Metadata": "8.0.0"
+        }
+      },
       "AngleSharp": {
         "type": "Transitive",
         "resolved": "1.3.0",

--- a/src/language-server/packages.lock.json
+++ b/src/language-server/packages.lock.json
@@ -901,6 +901,15 @@
           "System.Collections.Immutable": "8.0.0"
         }
       },
+      "System.Reflection.MetadataLoadContext": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "SZxrQ4sQYnIcdwiO3G/lHZopbPYQ2lW0ioT4JezgccWUrKaKbHLJbAGZaDfkYjWcta1pWssAo3MOXLsR0ie4tQ==",
+        "dependencies": {
+          "System.Collections.Immutable": "8.0.0",
+          "System.Reflection.Metadata": "8.0.0"
+        }
+      },
       "System.Reflection.Primitives": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1238,6 +1247,7 @@
           "Fifth.System": "[1.0.0, )",
           "Microsoft.CodeAnalysis.CSharp": "[4.11.0, )",
           "System.CommandLine": "[2.0.0-beta4.22272.1, )",
+          "System.Reflection.MetadataLoadContext": "[8.0.0, )",
           "ast_generated": "[1.0.0, )",
           "ast_model": "[1.0.0, )",
           "parser": "[1.0.0, )"

--- a/test/ast-tests/CrossProjectReferencePropertyTests.cs
+++ b/test/ast-tests/CrossProjectReferencePropertyTests.cs
@@ -1,0 +1,1072 @@
+// Feature: sdk-cross-project-references, Property 1: Absolute Path Resolution
+// Validates: Requirements 1.2, 1.3, 8.1, 8.2, 8.3
+
+using FsCheck;
+using FsCheck.Xunit;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using compiler;
+using System.Text;
+
+namespace ast_tests;
+
+/// <summary>
+/// Property-based tests for the absolute path resolution logic used by
+/// the GetTargetPath MSBuild target in Sdk.targets.
+///
+/// The target checks if FifthOutputPath is already absolute (rooted).
+/// If relative, it prepends MSBuildProjectDirectory to make it absolute.
+/// If already absolute, it returns the path unchanged.
+/// </summary>
+public class CrossProjectReferencePropertyTests
+{
+    /// <summary>
+    /// Simulates the GetTargetPath resolution logic from Sdk.targets:
+    /// - If outputPath is rooted, return it unchanged
+    /// - If outputPath is relative, combine projectDir + outputPath
+    /// </summary>
+    private static string ResolveOutputPath(string projectDir, string outputPath)
+    {
+        if (Path.IsPathRooted(outputPath))
+        {
+            return outputPath;
+        }
+
+        return Path.Combine(projectDir, outputPath);
+    }
+
+    /// <summary>
+    /// Generates valid directory path segments (no invalid path chars).
+    /// </summary>
+    private static Arbitrary<string> SafePathSegment()
+    {
+        return Arb.Default.NonEmptyString()
+            .Filter(s =>
+            {
+                var str = s.Get;
+                return !string.IsNullOrWhiteSpace(str)
+                    && str.IndexOfAny(Path.GetInvalidPathChars()) < 0
+                    && str.IndexOfAny(Path.GetInvalidFileNameChars()
+                        .Where(c => c != Path.DirectorySeparatorChar && c != Path.AltDirectorySeparatorChar)
+                        .ToArray()) < 0
+                    && !str.Contains("..");
+            })
+            .Generator
+            .Select(s => s.Get)
+            .ToArbitrary();
+    }
+
+    [Property(MaxTest = 100)]
+    public Property CombiningProjectDirAndRelativePath_AlwaysProducesRootedPath()
+    {
+        // Generate a rooted project directory and a relative output path
+        var gen = from dirSegment in SafePathSegment().Generator
+                  from fileSegment in SafePathSegment().Generator
+                  let projectDir = Path.Combine(Path.GetTempPath(), dirSegment)
+                  let relativePath = Path.Combine("bin", "Debug", "net8.0", fileSegment + ".dll")
+                  select (projectDir, relativePath);
+
+        return Prop.ForAll(gen.ToArbitrary(), tuple =>
+        {
+            var (projectDir, relativePath) = tuple;
+
+            // The relative path should not be rooted
+            if (Path.IsPathRooted(relativePath))
+                return true.ToProperty(); // skip — not a valid relative path for this test
+
+            var resolved = ResolveOutputPath(projectDir, relativePath);
+            return Path.IsPathRooted(resolved).ToProperty();
+        });
+    }
+
+    [Property(MaxTest = 100)]
+    public Property AbsolutePath_IsReturnedUnchanged()
+    {
+        // Generate absolute paths
+        var gen = from segment in SafePathSegment().Generator
+                  let absolutePath = Path.Combine(Path.GetTempPath(), "projects", segment, "bin", "Debug", "net8.0", segment + ".dll")
+                  select absolutePath;
+
+        return Prop.ForAll(gen.ToArbitrary(), absolutePath =>
+        {
+            // Verify the generated path is indeed rooted
+            if (!Path.IsPathRooted(absolutePath))
+                return true.ToProperty(); // skip — generator produced non-rooted path
+
+            var resolved = ResolveOutputPath("C:\\SomeOtherDir", absolutePath);
+            return (resolved == absolutePath).ToProperty();
+        });
+    }
+
+    [Property(MaxTest = 100)]
+    public Property ResolvedPath_IsAlwaysRooted_RegardlessOfInput()
+    {
+        // Generate random combinations of project dirs and output paths (both relative and absolute)
+        var gen = from dirSegment in SafePathSegment().Generator
+                  from fileSegment in SafePathSegment().Generator
+                  from useAbsolute in Arb.Default.Bool().Generator
+                  let projectDir = Path.Combine(Path.GetTempPath(), dirSegment)
+                  let outputPath = useAbsolute
+                      ? Path.Combine(Path.GetTempPath(), fileSegment, fileSegment + ".dll")
+                      : Path.Combine("bin", fileSegment + ".dll")
+                  select (projectDir, outputPath);
+
+        return Prop.ForAll(gen.ToArbitrary(), tuple =>
+        {
+            var (projectDir, outputPath) = tuple;
+            var resolved = ResolveOutputPath(projectDir, outputPath);
+            return Path.IsPathRooted(resolved).ToProperty();
+        });
+    }
+}
+
+// Feature: sdk-cross-project-references, Property 2: Public Static Type Discovery Completeness
+// Validates: Requirements 3.1, 3.2, 3.3
+
+/// <summary>
+/// Property-based tests verifying that DiscoverPublicStaticTypes returns exactly
+/// the public static types with public static methods from a compiled assembly,
+/// ignoring non-static classes and static classes without public static methods.
+/// </summary>
+public class PublicStaticTypeDiscoveryPropertyTests : IDisposable
+{
+    private readonly List<string> _tempFiles = new();
+
+    public void Dispose()
+    {
+        foreach (var f in _tempFiles)
+        {
+            try { if (File.Exists(f)) File.Delete(f); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Represents a generated class definition for test assembly compilation.
+    /// </summary>
+    private record ClassDef(string Name, string Namespace, bool IsStatic, int PublicStaticMethodCount, int InstanceMethodCount);
+
+    /// <summary>
+    /// Generates a valid C# identifier from a seed index.
+    /// </summary>
+    private static string MakeIdentifier(string prefix, int index) => $"{prefix}{index}";
+
+    /// <summary>
+    /// Builds C# source code from a list of class definitions.
+    /// </summary>
+    private static string BuildSource(IReadOnlyList<ClassDef> classes)
+    {
+        var sb = new StringBuilder();
+        foreach (var cls in classes)
+        {
+            sb.AppendLine($"namespace {cls.Namespace}");
+            sb.AppendLine("{");
+            sb.Append("    public ");
+            if (cls.IsStatic) sb.Append("static ");
+            sb.AppendLine($"class {cls.Name}");
+            sb.AppendLine("    {");
+
+            for (var i = 0; i < cls.PublicStaticMethodCount; i++)
+            {
+                sb.AppendLine($"        public static int StaticMethod{i}() => {i};");
+            }
+
+            for (var i = 0; i < cls.InstanceMethodCount; i++)
+            {
+                sb.AppendLine($"        public int InstanceMethod{i}() => {i};");
+            }
+
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Compiles C# source to a temporary DLL on disk and returns the path.
+    /// </summary>
+    private string CompileToDll(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        var references = new[]
+        {
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Private.CoreLib.dll")),
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+        };
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: $"TestAssembly_{Guid.NewGuid():N}",
+            syntaxTrees: new[] { syntaxTree },
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var tempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.dll");
+        _tempFiles.Add(tempPath);
+
+        var result = compilation.Emit(tempPath);
+        if (!result.Success)
+        {
+            var errors = string.Join("\n", result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+            throw new InvalidOperationException($"Compilation failed:\n{errors}\n\nSource:\n{source}");
+        }
+
+        return tempPath;
+    }
+
+    /// <summary>
+    /// FsCheck generator for a list of ClassDef instances with a mix of
+    /// public static classes (with at least one public static method) and
+    /// non-static noise classes.
+    /// </summary>
+    private static Gen<IReadOnlyList<ClassDef>> ClassDefsGen()
+    {
+        // Generate 1-8 public static classes, each with 1-5 public static methods
+        var staticClassGen =
+            from index in Gen.Choose(0, 999)
+            from methodCount in Gen.Choose(1, 5)
+            from instanceMethodCount in Gen.Choose(0, 3)
+            select new ClassDef(
+                Name: MakeIdentifier("StaticClass", index),
+                Namespace: "TestNs",
+                IsStatic: true,
+                PublicStaticMethodCount: methodCount,
+                InstanceMethodCount: 0); // static classes can't have instance methods
+
+        // Generate 0-5 non-static noise classes
+        var noiseClassGen =
+            from index in Gen.Choose(0, 999)
+            from instanceMethodCount in Gen.Choose(0, 3)
+            select new ClassDef(
+                Name: MakeIdentifier("NoiseClass", index),
+                Namespace: "TestNs",
+                IsStatic: false,
+                PublicStaticMethodCount: 0,
+                InstanceMethodCount: instanceMethodCount);
+
+        // Generate 0-3 static classes with NO public static methods (should be excluded)
+        var emptyStaticClassGen =
+            from index in Gen.Choose(0, 999)
+            select new ClassDef(
+                Name: MakeIdentifier("EmptyStaticClass", index),
+                Namespace: "TestNs",
+                IsStatic: true,
+                PublicStaticMethodCount: 0,
+                InstanceMethodCount: 0);
+
+        return from staticCount in Gen.Choose(1, 8)
+               from noiseCount in Gen.Choose(0, 5)
+               from emptyStaticCount in Gen.Choose(0, 3)
+               from statics in Gen.ListOf(staticCount, staticClassGen)
+               from noises in Gen.ListOf(noiseCount, noiseClassGen)
+               from empties in Gen.ListOf(emptyStaticCount, emptyStaticClassGen)
+               // Deduplicate names by appending unique suffix
+               let allClasses = DeduplicateNames(statics.Concat(noises).Concat(empties).ToList())
+               select (IReadOnlyList<ClassDef>)allClasses;
+    }
+
+    /// <summary>
+    /// Ensures all class names are unique by appending a suffix when duplicates exist.
+    /// </summary>
+    private static List<ClassDef> DeduplicateNames(List<ClassDef> classes)
+    {
+        var seen = new HashSet<string>();
+        var result = new List<ClassDef>();
+        var counter = 0;
+        foreach (var cls in classes)
+        {
+            var name = cls.Name;
+            while (!seen.Add(name))
+            {
+                name = $"{cls.Name}_{counter++}";
+            }
+            result.Add(cls with { Name = name });
+        }
+        return result;
+    }
+
+    [Property(MaxTest = 100)]
+    public Property DiscoverPublicStaticTypes_ReturnsExactlyPublicStaticTypesWithMethods()
+    {
+        return Prop.ForAll(ClassDefsGen().ToArbitrary(), classDefs =>
+        {
+            // Build source and compile to DLL
+            var source = BuildSource(classDefs);
+            var dllPath = CompileToDll(source);
+
+            // Call the method under test
+            var discovered = LoweredAstToRoslynTranslator.DiscoverPublicStaticTypes(dllPath);
+
+            // Compute expected: only static classes with at least one public static method
+            var expected = classDefs
+                .Where(c => c.IsStatic && c.PublicStaticMethodCount > 0)
+                .Select(c => $"{c.Namespace}.{c.Name}")
+                .OrderBy(n => n)
+                .ToList();
+
+            var actual = discovered.OrderBy(n => n).ToList();
+
+            // Property: discovered set matches expected set exactly
+            return (actual.Count == expected.Count &&
+                    actual.SequenceEqual(expected))
+                .ToProperty()
+                .Label($"Expected: [{string.Join(", ", expected)}], Actual: [{string.Join(", ", actual)}]");
+        });
+    }
+
+    [Property(MaxTest = 100)]
+    public Property DiscoverPublicStaticTypes_AllReturnedTypesArePublicStaticWithMethods()
+    {
+        return Prop.ForAll(ClassDefsGen().ToArbitrary(), classDefs =>
+        {
+            var source = BuildSource(classDefs);
+            var dllPath = CompileToDll(source);
+
+            var discovered = LoweredAstToRoslynTranslator.DiscoverPublicStaticTypes(dllPath);
+
+            // Build a lookup of expected qualifying types
+            var qualifyingTypes = new HashSet<string>(
+                classDefs
+                    .Where(c => c.IsStatic && c.PublicStaticMethodCount > 0)
+                    .Select(c => $"{c.Namespace}.{c.Name}"));
+
+            // Property: every discovered type is in the qualifying set
+            return discovered.All(t => qualifyingTypes.Contains(t))
+                .ToProperty()
+                .Label($"Discovered types not in qualifying set: [{string.Join(", ", discovered.Where(t => !qualifyingTypes.Contains(t)))}]");
+        });
+    }
+
+    [Property(MaxTest = 100)]
+    public Property DiscoverPublicStaticTypes_NeverReturnsNonStaticOrEmptyStaticClasses()
+    {
+        return Prop.ForAll(ClassDefsGen().ToArbitrary(), classDefs =>
+        {
+            var source = BuildSource(classDefs);
+            var dllPath = CompileToDll(source);
+
+            var discovered = new HashSet<string>(
+                LoweredAstToRoslynTranslator.DiscoverPublicStaticTypes(dllPath));
+
+            // Noise classes (non-static) should never appear
+            var noiseTypes = classDefs
+                .Where(c => !c.IsStatic)
+                .Select(c => $"{c.Namespace}.{c.Name}");
+
+            // Empty static classes (no public static methods) should never appear
+            var emptyStaticTypes = classDefs
+                .Where(c => c.IsStatic && c.PublicStaticMethodCount == 0)
+                .Select(c => $"{c.Namespace}.{c.Name}");
+
+            var excludedTypes = noiseTypes.Concat(emptyStaticTypes).ToList();
+            var wronglyIncluded = excludedTypes.Where(t => discovered.Contains(t)).ToList();
+
+            return (!wronglyIncluded.Any())
+                .ToProperty()
+                .Label($"Wrongly included types: [{string.Join(", ", wronglyIncluded)}]");
+        });
+    }
+}
+
+// Feature: sdk-cross-project-references, Property 3: Using Static Generation Correctness
+// Validates: Requirements 4.1, 4.2
+
+/// <summary>
+/// Property-based tests verifying that the translator generates a `using static` directive
+/// for every public static type (with public static methods) discovered in referenced assemblies,
+/// and that each directive uses the fully qualified type name.
+/// </summary>
+public class UsingStaticGenerationPropertyTests : IDisposable
+{
+    private readonly List<string> _tempFiles = new();
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        foreach (var f in _tempFiles)
+        {
+            try { if (File.Exists(f)) File.Delete(f); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Represents a generated class definition for test assembly compilation.
+    /// </summary>
+    private record ClassDef(string Name, string Namespace, bool IsStatic, int PublicStaticMethodCount);
+
+    /// <summary>
+    /// Builds C# source code from a list of class definitions.
+    /// </summary>
+    private static string BuildSource(IReadOnlyList<ClassDef> classes)
+    {
+        var sb = new StringBuilder();
+        foreach (var cls in classes)
+        {
+            sb.AppendLine($"namespace {cls.Namespace}");
+            sb.AppendLine("{");
+            sb.Append("    public ");
+            if (cls.IsStatic) sb.Append("static ");
+            sb.AppendLine($"class {cls.Name}");
+            sb.AppendLine("    {");
+
+            for (var i = 0; i < cls.PublicStaticMethodCount; i++)
+            {
+                sb.AppendLine($"        public static int Method{i}() => {i};");
+            }
+
+            // Non-static classes need at least a body to compile
+            if (!cls.IsStatic && cls.PublicStaticMethodCount == 0)
+            {
+                sb.AppendLine("        public int Dummy() => 0;");
+            }
+
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Compiles C# source to a temporary DLL on disk and returns the path.
+    /// </summary>
+    private string CompileToDll(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        var references = new[]
+        {
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Private.CoreLib.dll")),
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+        };
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: $"TestAssembly_{Guid.NewGuid():N}",
+            syntaxTrees: new[] { syntaxTree },
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var tempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.dll");
+        _tempFiles.Add(tempPath);
+
+        var result = compilation.Emit(tempPath);
+        if (!result.Success)
+        {
+            var errors = string.Join("\n", result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+            throw new InvalidOperationException($"Compilation failed:\n{errors}\n\nSource:\n{source}");
+        }
+
+        return tempPath;
+    }
+
+    /// <summary>
+    /// Creates a minimal AssemblyDef with one empty module suitable for translation.
+    /// </summary>
+    private static ast.AssemblyDef CreateMinimalAssemblyDef()
+    {
+        var voidType = new ast_model.TypeSystem.FifthType.TVoidType { Name = ast_model.TypeSystem.TypeName.From("void") };
+        var module = new ast.ModuleDef
+        {
+            Annotations = new Dictionary<string, object>(),
+            OriginalModuleName = "TestModule",
+            NamespaceDecl = ast.NamespaceName.From("TestModule"),
+            Classes = [],
+            Functions = [],
+            Type = voidType,
+            Parent = null,
+            Visibility = ast.Visibility.Public
+        };
+
+        return new ast.AssemblyDef
+        {
+            Annotations = new Dictionary<string, object>(),
+            Name = ast.AssemblyName.From("TestAssembly"),
+            PublicKeyToken = "",
+            Version = "0.0.0",
+            TestProperty = "",
+            AssemblyRefs = [],
+            Modules = [module],
+            Type = voidType,
+            Parent = null,
+            Visibility = ast.Visibility.Public
+        };
+    }
+
+    /// <summary>
+    /// Extracts all `using static` directive type names from a C# source string.
+    /// </summary>
+    private static HashSet<string> ExtractUsingStaticDirectives(string csharpSource)
+    {
+        var tree = CSharpSyntaxTree.ParseText(csharpSource);
+        var root = tree.GetCompilationUnitRoot();
+        var result = new HashSet<string>(StringComparer.Ordinal);
+
+        // Check top-level using directives
+        foreach (var usingDir in root.Usings)
+        {
+            if (usingDir.StaticKeyword.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword))
+            {
+                result.Add(usingDir.Name?.ToString() ?? "");
+            }
+        }
+
+        // Check namespace-level using directives
+        foreach (var member in root.Members)
+        {
+            if (member is Microsoft.CodeAnalysis.CSharp.Syntax.NamespaceDeclarationSyntax ns)
+            {
+                foreach (var usingDir in ns.Usings)
+                {
+                    if (usingDir.StaticKeyword.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword))
+                    {
+                        result.Add(usingDir.Name?.ToString() ?? "");
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Ensures all class names are unique by appending a suffix when duplicates exist.
+    /// </summary>
+    private static List<ClassDef> DeduplicateNames(List<ClassDef> classes)
+    {
+        var seen = new HashSet<string>();
+        var result = new List<ClassDef>();
+        var counter = 0;
+        foreach (var cls in classes)
+        {
+            var name = cls.Name;
+            while (!seen.Add(name))
+            {
+                name = $"{cls.Name}_{counter++}";
+            }
+            result.Add(cls with { Name = name });
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// FsCheck generator for sets of public static classes across 1-3 assemblies.
+    /// Each assembly gets 1-4 public static classes with 1-3 public static methods.
+    /// </summary>
+    private static Gen<IReadOnlyList<IReadOnlyList<ClassDef>>> AssemblyClassDefsGen()
+    {
+        var staticClassGen = (string nsPrefix) =>
+            from index in Gen.Choose(0, 999)
+            from methodCount in Gen.Choose(1, 3)
+            select new ClassDef(
+                Name: $"Cls{index}",
+                Namespace: $"{nsPrefix}",
+                IsStatic: true,
+                PublicStaticMethodCount: methodCount);
+
+        return from assemblyCount in Gen.Choose(1, 3)
+               from assemblies in Gen.Sequence(
+                   Enumerable.Range(0, assemblyCount).Select(asmIdx =>
+                       from classCount in Gen.Choose(1, 4)
+                       from classes in Gen.ListOf(classCount, staticClassGen($"Ns{asmIdx}"))
+                       let deduped = DeduplicateNames(classes.ToList())
+                       select (IReadOnlyList<ClassDef>)deduped))
+               select (IReadOnlyList<IReadOnlyList<ClassDef>>)assemblies.ToList();
+    }
+
+    [Property(MaxTest = 100)]
+    public Property GeneratedCSharp_ContainsUsingStaticForEachDiscoveredType()
+    {
+        return Prop.ForAll(AssemblyClassDefsGen().ToArbitrary(), assemblyClassDefs =>
+        {
+            // Build and compile each assembly
+            var dllPaths = new List<string>();
+            var allExpectedTypes = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var classDefs in assemblyClassDefs)
+            {
+                var source = BuildSource(classDefs);
+                var dllPath = CompileToDll(source);
+                dllPaths.Add(dllPath);
+
+                foreach (var cls in classDefs.Where(c => c.IsStatic && c.PublicStaticMethodCount > 0))
+                {
+                    allExpectedTypes.Add($"{cls.Namespace}.{cls.Name}");
+                }
+            }
+
+            // Translate a minimal module with those assemblies as references
+            var assemblyDef = CreateMinimalAssemblyDef();
+            var translator = new LoweredAstToRoslynTranslator();
+            var options = new TranslatorOptions
+            {
+                AdditionalReferences = dllPaths
+            };
+
+            var result = translator.Translate(assemblyDef, options);
+
+            // Parse the generated C# to extract using static directives
+            var generatedSource = result.Sources.FirstOrDefault() ?? "";
+            var usingStatics = ExtractUsingStaticDirectives(generatedSource);
+
+            // Verify: every expected type has a corresponding using static directive
+            var missing = allExpectedTypes.Where(t => !usingStatics.Contains(t)).ToList();
+
+            return (missing.Count == 0)
+                .ToProperty()
+                .Label($"Missing using static directives: [{string.Join(", ", missing)}]");
+        });
+    }
+
+    [Property(MaxTest = 100)]
+    public Property GeneratedUsingStatics_UseFullyQualifiedTypeNames()
+    {
+        return Prop.ForAll(AssemblyClassDefsGen().ToArbitrary(), assemblyClassDefs =>
+        {
+            // Build and compile each assembly
+            var dllPaths = new List<string>();
+            var allExpectedTypes = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var classDefs in assemblyClassDefs)
+            {
+                var source = BuildSource(classDefs);
+                var dllPath = CompileToDll(source);
+                dllPaths.Add(dllPath);
+
+                foreach (var cls in classDefs.Where(c => c.IsStatic && c.PublicStaticMethodCount > 0))
+                {
+                    allExpectedTypes.Add($"{cls.Namespace}.{cls.Name}");
+                }
+            }
+
+            // Translate
+            var assemblyDef = CreateMinimalAssemblyDef();
+            var translator = new LoweredAstToRoslynTranslator();
+            var options = new TranslatorOptions
+            {
+                AdditionalReferences = dllPaths
+            };
+
+            var result = translator.Translate(assemblyDef, options);
+            var generatedSource = result.Sources.FirstOrDefault() ?? "";
+            var usingStatics = ExtractUsingStaticDirectives(generatedSource);
+
+            // Verify: each using static directive for our types uses fully qualified name
+            // (contains a dot, meaning namespace.class format)
+            var ourDirectives = usingStatics.Where(u => allExpectedTypes.Contains(u)).ToList();
+            var allFullyQualified = ourDirectives.All(d => d.Contains('.'));
+
+            return allFullyQualified
+                .ToProperty()
+                .Label($"Non-fully-qualified directives: [{string.Join(", ", ourDirectives.Where(d => !d.Contains('.')))}]");
+        });
+    }
+}
+
+// Feature: sdk-cross-project-references, Property 4: No Duplicate Using Static Directives
+// Validates: Requirements 4.3
+
+/// <summary>
+/// Property-based tests verifying that when multiple assemblies export types with the
+/// same fully qualified name, the translator emits at most one `using static` directive
+/// per unique type name — no duplicates.
+/// </summary>
+public class NoDuplicateUsingStaticPropertyTests : IDisposable
+{
+    private readonly List<string> _tempFiles = new();
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        foreach (var f in _tempFiles)
+        {
+            try { if (File.Exists(f)) File.Delete(f); } catch { }
+        }
+    }
+
+    private record ClassDef(string Name, string Namespace, bool IsStatic, int PublicStaticMethodCount);
+
+    private static string BuildSource(IReadOnlyList<ClassDef> classes)
+    {
+        var sb = new StringBuilder();
+        foreach (var cls in classes)
+        {
+            sb.AppendLine($"namespace {cls.Namespace}");
+            sb.AppendLine("{");
+            sb.Append("    public ");
+            if (cls.IsStatic) sb.Append("static ");
+            sb.AppendLine($"class {cls.Name}");
+            sb.AppendLine("    {");
+
+            for (var i = 0; i < cls.PublicStaticMethodCount; i++)
+            {
+                sb.AppendLine($"        public static int Method{i}() => {i};");
+            }
+
+            if (!cls.IsStatic && cls.PublicStaticMethodCount == 0)
+            {
+                sb.AppendLine("        public int Dummy() => 0;");
+            }
+
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+        }
+        return sb.ToString();
+    }
+
+    private string CompileToDll(string source, string assemblyName)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        var references = new[]
+        {
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Private.CoreLib.dll")),
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+        };
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: assemblyName,
+            syntaxTrees: new[] { syntaxTree },
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var tempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.dll");
+        _tempFiles.Add(tempPath);
+
+        var result = compilation.Emit(tempPath);
+        if (!result.Success)
+        {
+            var errors = string.Join("\n", result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+            throw new InvalidOperationException($"Compilation failed:\n{errors}\n\nSource:\n{source}");
+        }
+
+        return tempPath;
+    }
+
+    private static ast.AssemblyDef CreateMinimalAssemblyDef()
+    {
+        var voidType = new ast_model.TypeSystem.FifthType.TVoidType { Name = ast_model.TypeSystem.TypeName.From("void") };
+        var module = new ast.ModuleDef
+        {
+            Annotations = new Dictionary<string, object>(),
+            OriginalModuleName = "TestModule",
+            NamespaceDecl = ast.NamespaceName.From("TestModule"),
+            Classes = [],
+            Functions = [],
+            Type = voidType,
+            Parent = null,
+            Visibility = ast.Visibility.Public
+        };
+
+        return new ast.AssemblyDef
+        {
+            Annotations = new Dictionary<string, object>(),
+            Name = ast.AssemblyName.From("TestAssembly"),
+            PublicKeyToken = "",
+            Version = "0.0.0",
+            TestProperty = "",
+            AssemblyRefs = [],
+            Modules = [module],
+            Type = voidType,
+            Parent = null,
+            Visibility = ast.Visibility.Public
+        };
+    }
+
+    /// <summary>
+    /// Counts ALL `using static` directives in the generated C# source (including duplicates).
+    /// Unlike ExtractUsingStaticDirectives which returns a HashSet, this returns a raw list
+    /// so we can detect if the translator emitted duplicates.
+    /// </summary>
+    private static List<string> ExtractAllUsingStaticDirectives(string csharpSource)
+    {
+        var tree = CSharpSyntaxTree.ParseText(csharpSource);
+        var root = tree.GetCompilationUnitRoot();
+        var result = new List<string>();
+
+        foreach (var usingDir in root.Usings)
+        {
+            if (usingDir.StaticKeyword.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword))
+            {
+                result.Add(usingDir.Name?.ToString() ?? "");
+            }
+        }
+
+        foreach (var member in root.Members)
+        {
+            if (member is Microsoft.CodeAnalysis.CSharp.Syntax.NamespaceDeclarationSyntax ns)
+            {
+                foreach (var usingDir in ns.Usings)
+                {
+                    if (usingDir.StaticKeyword.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword))
+                    {
+                        result.Add(usingDir.Name?.ToString() ?? "");
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Generates a shared pool of type names, then distributes them across 2-4 assemblies
+    /// with intentional overlap so the same fully qualified type name appears in multiple assemblies.
+    /// </summary>
+    private static Gen<(IReadOnlyList<string> TypeNames, int AssemblyCount)> OverlappingTypeNamesGen()
+    {
+        return from typeCount in Gen.Choose(1, 6)
+               from indices in Gen.ListOf(typeCount, Gen.Choose(0, 99))
+               from assemblyCount in Gen.Choose(2, 4)
+               let distinctNames = indices.Select(i => $"SharedNs.StaticType{i}").Distinct().ToList()
+               where distinctNames.Count > 0
+               select ((IReadOnlyList<string>)distinctNames, assemblyCount);
+    }
+
+    [Property(MaxTest = 100)]
+    public Property UsingStaticCount_EqualsDistinctTypeCount_WhenDuplicatesAcrossAssemblies()
+    {
+        // **Validates: Requirements 4.3**
+        return Prop.ForAll(OverlappingTypeNamesGen().ToArbitrary(), input =>
+        {
+            var (typeNames, assemblyCount) = input;
+
+            // Create multiple assemblies, each containing ALL the shared type names.
+            // This means every type name appears in every assembly — maximum overlap.
+            var dllPaths = new List<string>();
+            var classDefs = typeNames.Select(fqn =>
+            {
+                var parts = fqn.Split('.');
+                var ns = parts[0];
+                var name = parts[1];
+                return new ClassDef(name, ns, IsStatic: true, PublicStaticMethodCount: 1);
+            }).ToList();
+
+            for (var asmIdx = 0; asmIdx < assemblyCount; asmIdx++)
+            {
+                var source = BuildSource(classDefs);
+                var dllPath = CompileToDll(source, $"OverlapAsm{asmIdx}_{Guid.NewGuid():N}");
+                dllPaths.Add(dllPath);
+            }
+
+            // Translate with all assemblies as references
+            var assemblyDef = CreateMinimalAssemblyDef();
+            var translator = new LoweredAstToRoslynTranslator();
+            var options = new TranslatorOptions
+            {
+                AdditionalReferences = dllPaths
+            };
+
+            var result = translator.Translate(assemblyDef, options);
+            var generatedSource = result.Sources.FirstOrDefault() ?? "";
+
+            // Extract ALL using static directives (as a list, preserving duplicates)
+            var allDirectives = ExtractAllUsingStaticDirectives(generatedSource);
+
+            // Filter to only our shared type names
+            var ourTypeSet = new HashSet<string>(typeNames, StringComparer.Ordinal);
+            var ourDirectives = allDirectives.Where(d => ourTypeSet.Contains(d)).ToList();
+
+            // Property: count of using static directives for our types == count of distinct type names
+            var distinctCount = typeNames.Count; // already distinct from generator
+            return (ourDirectives.Count == distinctCount)
+                .ToProperty()
+                .Label($"Expected {distinctCount} using static directives, got {ourDirectives.Count}. " +
+                       $"Types: [{string.Join(", ", typeNames)}], " +
+                       $"Directives: [{string.Join(", ", ourDirectives)}]");
+        });
+    }
+}
+
+// Feature: sdk-cross-project-references, Property 5: Backward Compatibility — No Extra Directives Without References
+// Validates: Requirements 4.4, 9.2, 9.3
+
+/// <summary>
+/// Property-based tests verifying that when no additional references are provided
+/// (AdditionalReferences = null), the translator produces only the known default
+/// set of using static directives — no extras appear regardless of module complexity.
+/// </summary>
+public class BackwardCompatibilityPropertyTests
+{
+    /// <summary>
+    /// The known default set of using static directives emitted by the translator
+    /// when no additional references are provided.
+    /// </summary>
+    private static readonly HashSet<string> DefaultUsingStatics = new(StringComparer.Ordinal)
+    {
+        "Fifth.System.Functional",
+        "Fifth.System.List",
+        "Fifth.System.IO",
+        "Fifth.System.Math"
+    };
+
+    /// <summary>
+    /// Creates an AssemblyDef with one module containing the given number of simple functions.
+    /// Each function returns an int literal, simulating varying module complexity.
+    /// </summary>
+    private static ast.AssemblyDef CreateAssemblyDefWithFunctions(int functionCount)
+    {
+        var intType = new ast_model.TypeSystem.FifthType.TType { Name = ast_model.TypeSystem.TypeName.From("int") };
+        var voidType = new ast_model.TypeSystem.FifthType.TVoidType { Name = ast_model.TypeSystem.TypeName.From("void") };
+
+        var functions = new List<ast.ScopedDefinition>();
+        for (var i = 0; i < functionCount; i++)
+        {
+            var returnExp = new ast.Int32LiteralExp
+            {
+                Value = i,
+                Annotations = new Dictionary<string, object>(),
+                Type = intType,
+                Parent = null
+            };
+
+            var body = new ast.BlockStatement
+            {
+                Statements = [new ast.ReturnStatement
+                {
+                    ReturnValue = returnExp,
+                    Annotations = new Dictionary<string, object>(),
+                    Type = voidType,
+                    Parent = null
+                }],
+                Annotations = new Dictionary<string, object>(),
+                Type = voidType,
+                Parent = null
+            };
+
+            var funcDef = new ast.FunctionDef
+            {
+                Name = ast.MemberName.From($"func{i}"),
+                TypeParameters = [],
+                Params = [],
+                Body = body,
+                ReturnType = intType,
+                IsStatic = true,
+                IsConstructor = false,
+                Annotations = new Dictionary<string, object>(),
+                Type = intType,
+                Parent = null,
+                Visibility = ast.Visibility.Public
+            };
+
+            functions.Add(funcDef);
+        }
+
+        var module = new ast.ModuleDef
+        {
+            Annotations = new Dictionary<string, object>(),
+            OriginalModuleName = "TestModule",
+            NamespaceDecl = ast.NamespaceName.From("TestModule"),
+            Classes = [],
+            Functions = functions,
+            Type = voidType,
+            Parent = null,
+            Visibility = ast.Visibility.Public
+        };
+
+        return new ast.AssemblyDef
+        {
+            Annotations = new Dictionary<string, object>(),
+            Name = ast.AssemblyName.From("TestAssembly"),
+            PublicKeyToken = "",
+            Version = "0.0.0",
+            TestProperty = "",
+            AssemblyRefs = [],
+            Modules = [module],
+            Type = voidType,
+            Parent = null,
+            Visibility = ast.Visibility.Public
+        };
+    }
+
+    /// <summary>
+    /// Extracts all using static directive type names from a C# source string.
+    /// </summary>
+    private static HashSet<string> ExtractUsingStaticDirectives(string csharpSource)
+    {
+        var tree = CSharpSyntaxTree.ParseText(csharpSource);
+        var root = tree.GetCompilationUnitRoot();
+        var result = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var usingDir in root.Usings)
+        {
+            if (usingDir.StaticKeyword.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword))
+            {
+                result.Add(usingDir.Name?.ToString() ?? "");
+            }
+        }
+
+        foreach (var member in root.Members)
+        {
+            if (member is Microsoft.CodeAnalysis.CSharp.Syntax.NamespaceDeclarationSyntax ns)
+            {
+                foreach (var usingDir in ns.Usings)
+                {
+                    if (usingDir.StaticKeyword.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.StaticKeyword))
+                    {
+                        result.Add(usingDir.Name?.ToString() ?? "");
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    [Property(MaxTest = 100)]
+    public Property NoAdditionalReferences_ProducesOnlyDefaultUsingStatics()
+    {
+        // **Validates: Requirements 4.4, 9.2, 9.3**
+        // Generate modules with 0-5 functions and verify no extra using static directives appear
+        var gen = Gen.Choose(0, 5);
+
+        return Prop.ForAll(gen.ToArbitrary(), functionCount =>
+        {
+            var assemblyDef = CreateAssemblyDefWithFunctions(functionCount);
+            var translator = new LoweredAstToRoslynTranslator();
+
+            // Translate with AdditionalReferences = null (backward-compatible path)
+            var result = translator.Translate(assemblyDef, null);
+            var generatedSource = result.Sources.FirstOrDefault() ?? "";
+
+            var usingStatics = ExtractUsingStaticDirectives(generatedSource);
+
+            // Property: the using static set must be exactly the default set
+            var extra = usingStatics.Except(DefaultUsingStatics).ToList();
+            var missing = DefaultUsingStatics.Except(usingStatics).ToList();
+
+            return (extra.Count == 0 && missing.Count == 0)
+                .ToProperty()
+                .Label($"FunctionCount={functionCount}. " +
+                       $"Extra directives: [{string.Join(", ", extra)}], " +
+                       $"Missing directives: [{string.Join(", ", missing)}]");
+        });
+    }
+
+    [Property(MaxTest = 100)]
+    public Property NoAdditionalReferences_WithoutOptions_ProducesOnlyDefaultUsingStatics()
+    {
+        // **Validates: Requirements 4.4, 9.2, 9.3**
+        // Same as above but calling the no-options Translate overload
+        var gen = Gen.Choose(0, 5);
+
+        return Prop.ForAll(gen.ToArbitrary(), functionCount =>
+        {
+            var assemblyDef = CreateAssemblyDefWithFunctions(functionCount);
+            var translator = new LoweredAstToRoslynTranslator();
+
+            // Translate without passing TranslatorOptions at all
+            var result = translator.Translate(assemblyDef);
+            var generatedSource = result.Sources.FirstOrDefault() ?? "";
+
+            var usingStatics = ExtractUsingStaticDirectives(generatedSource);
+
+            // Property: the using static set must be exactly the default set
+            var extra = usingStatics.Except(DefaultUsingStatics).ToList();
+            var missing = DefaultUsingStatics.Except(usingStatics).ToList();
+
+            return (extra.Count == 0 && missing.Count == 0)
+                .ToProperty()
+                .Label($"FunctionCount={functionCount}. " +
+                       $"Extra directives: [{string.Join(", ", extra)}], " +
+                       $"Missing directives: [{string.Join(", ", missing)}]");
+        });
+    }
+}

--- a/test/ast-tests/CrossProjectReferenceTests.cs
+++ b/test/ast-tests/CrossProjectReferenceTests.cs
@@ -1,0 +1,434 @@
+// Unit tests for cross-project reference translator functionality
+// Validates: Requirements 3.1, 3.2, 3.3, 3.4, 4.1, 4.2, 4.3, 4.4, 9.2, 9.3
+
+using FluentAssertions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using compiler;
+using System.Text;
+
+namespace ast_tests;
+
+/// <summary>
+/// Unit tests for DiscoverPublicStaticTypes — verifies specific examples and edge cases
+/// for the reflection-based type discovery in the Roslyn translator.
+/// </summary>
+public class DiscoverPublicStaticTypesTests : IDisposable
+{
+    private readonly List<string> _tempFiles = new();
+
+    public void Dispose()
+    {
+        foreach (var f in _tempFiles)
+        {
+            try { if (File.Exists(f)) File.Delete(f); } catch { }
+        }
+    }
+
+    private string CompileToDll(string source)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        var references = new[]
+        {
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Private.CoreLib.dll")),
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+        };
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: $"TestAsm_{Guid.NewGuid():N}",
+            syntaxTrees: new[] { syntaxTree },
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var tempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.dll");
+        _tempFiles.Add(tempPath);
+
+        var result = compilation.Emit(tempPath);
+        if (!result.Success)
+        {
+            var errors = string.Join("\n", result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+            throw new InvalidOperationException($"Compilation failed:\n{errors}\n\nSource:\n{source}");
+        }
+
+        return tempPath;
+    }
+
+    [Fact]
+    public void OnePublicStaticClass_ReturnsThatClassName()
+    {
+        // Validates: Requirements 3.1, 3.2, 3.3
+        var source = @"
+namespace MyLib
+{
+    public static class Helpers
+    {
+        public static int Add(int a, int b) => a + b;
+    }
+}";
+        var dllPath = CompileToDll(source);
+
+        var result = LoweredAstToRoslynTranslator.DiscoverPublicStaticTypes(dllPath);
+
+        result.Should().ContainSingle()
+            .Which.Should().Be("MyLib.Helpers");
+    }
+
+    [Fact]
+    public void NoPublicStaticClasses_ReturnsEmptyList()
+    {
+        // Validates: Requirements 3.2, 3.3
+        var source = @"
+namespace MyLib
+{
+    public class RegularClass
+    {
+        public int GetValue() => 42;
+    }
+}";
+        var dllPath = CompileToDll(source);
+
+        var result = LoweredAstToRoslynTranslator.DiscoverPublicStaticTypes(dllPath);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MixOfStaticAndNonStatic_ReturnsOnlyStaticOnes()
+    {
+        // Validates: Requirements 3.1, 3.2, 3.3
+        var source = @"
+namespace MixLib
+{
+    public static class StaticHelper
+    {
+        public static int Square(int x) => x * x;
+    }
+
+    public class InstanceClass
+    {
+        public int Value { get; set; }
+    }
+
+    public static class AnotherStatic
+    {
+        public static string Greet() => ""hello"";
+    }
+
+    internal class InternalClass
+    {
+        public int Foo() => 1;
+    }
+}";
+        var dllPath = CompileToDll(source);
+
+        var result = LoweredAstToRoslynTranslator.DiscoverPublicStaticTypes(dllPath);
+
+        result.Should().HaveCount(2);
+        result.Should().Contain("MixLib.StaticHelper");
+        result.Should().Contain("MixLib.AnotherStatic");
+        result.Should().NotContain("MixLib.InstanceClass");
+        result.Should().NotContain("MixLib.InternalClass");
+    }
+
+    [Fact]
+    public void NonExistentPath_ReturnsEmptyList()
+    {
+        // Validates: Requirement 3.4
+        var fakePath = Path.Combine(Path.GetTempPath(), $"nonexistent_{Guid.NewGuid():N}.dll");
+
+        var result = LoweredAstToRoslynTranslator.DiscoverPublicStaticTypes(fakePath);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void InvalidDll_ReturnsEmptyList()
+    {
+        // Validates: Requirement 3.4
+        var tempPath = Path.Combine(Path.GetTempPath(), $"garbage_{Guid.NewGuid():N}.dll");
+        _tempFiles.Add(tempPath);
+        File.WriteAllBytes(tempPath, new byte[] { 0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01, 0x02, 0x03 });
+
+        var result = LoweredAstToRoslynTranslator.DiscoverPublicStaticTypes(tempPath);
+
+        result.Should().BeEmpty();
+    }
+}
+
+
+/// <summary>
+/// Unit tests for BuildSyntaxTreeFromModule using directive generation —
+/// verifies that the translator correctly generates using static directives
+/// when additional references are provided.
+/// </summary>
+public class TranslatorUsingDirectiveTests : IDisposable
+{
+    private readonly List<string> _tempFiles = new();
+
+    public void Dispose()
+    {
+        foreach (var f in _tempFiles)
+        {
+            try { if (File.Exists(f)) File.Delete(f); } catch { }
+        }
+    }
+
+    private string CompileToDll(string source, string? assemblyName = null)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source);
+        var runtimeDir = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+        var references = new[]
+        {
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Private.CoreLib.dll")),
+            MetadataReference.CreateFromFile(Path.Combine(runtimeDir, "System.Runtime.dll")),
+        };
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName: assemblyName ?? $"TestAsm_{Guid.NewGuid():N}",
+            syntaxTrees: new[] { syntaxTree },
+            references: references,
+            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var tempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.dll");
+        _tempFiles.Add(tempPath);
+
+        var result = compilation.Emit(tempPath);
+        if (!result.Success)
+        {
+            var errors = string.Join("\n", result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+            throw new InvalidOperationException($"Compilation failed:\n{errors}\n\nSource:\n{source}");
+        }
+
+        return tempPath;
+    }
+
+    private static ast.AssemblyDef CreateMinimalAssemblyDef()
+    {
+        var voidType = new ast_model.TypeSystem.FifthType.TVoidType
+        {
+            Name = ast_model.TypeSystem.TypeName.From("void")
+        };
+        var module = new ast.ModuleDef
+        {
+            Annotations = new Dictionary<string, object>(),
+            OriginalModuleName = "TestModule",
+            NamespaceDecl = ast.NamespaceName.From("TestModule"),
+            Classes = [],
+            Functions = [],
+            Type = voidType,
+            Parent = null,
+            Visibility = ast.Visibility.Public
+        };
+
+        return new ast.AssemblyDef
+        {
+            Annotations = new Dictionary<string, object>(),
+            Name = ast.AssemblyName.From("TestAssembly"),
+            PublicKeyToken = "",
+            Version = "0.0.0",
+            TestProperty = "",
+            AssemblyRefs = [],
+            Modules = [module],
+            Type = voidType,
+            Parent = null,
+            Visibility = ast.Visibility.Public
+        };
+    }
+
+    /// <summary>
+    /// Extracts all using static directive type names from generated C# source.
+    /// </summary>
+    private static HashSet<string> ExtractUsingStaticDirectives(string csharpSource)
+    {
+        var tree = CSharpSyntaxTree.ParseText(csharpSource);
+        var root = tree.GetCompilationUnitRoot();
+        var result = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var usingDir in root.Usings)
+        {
+            if (usingDir.StaticKeyword.IsKind(SyntaxKind.StaticKeyword))
+            {
+                result.Add(usingDir.Name?.ToString() ?? "");
+            }
+        }
+
+        foreach (var member in root.Members)
+        {
+            if (member is NamespaceDeclarationSyntax ns)
+            {
+                foreach (var usingDir in ns.Usings)
+                {
+                    if (usingDir.StaticKeyword.IsKind(SyntaxKind.StaticKeyword))
+                    {
+                        result.Add(usingDir.Name?.ToString() ?? "");
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Extracts all using static directives as a list (preserving duplicates).
+    /// </summary>
+    private static List<string> ExtractAllUsingStaticDirectives(string csharpSource)
+    {
+        var tree = CSharpSyntaxTree.ParseText(csharpSource);
+        var root = tree.GetCompilationUnitRoot();
+        var result = new List<string>();
+
+        foreach (var usingDir in root.Usings)
+        {
+            if (usingDir.StaticKeyword.IsKind(SyntaxKind.StaticKeyword))
+            {
+                result.Add(usingDir.Name?.ToString() ?? "");
+            }
+        }
+
+        foreach (var member in root.Members)
+        {
+            if (member is NamespaceDeclarationSyntax ns)
+            {
+                foreach (var usingDir in ns.Usings)
+                {
+                    if (usingDir.StaticKeyword.IsKind(SyntaxKind.StaticKeyword))
+                    {
+                        result.Add(usingDir.Name?.ToString() ?? "");
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static readonly HashSet<string> DefaultUsingStatics = new(StringComparer.Ordinal)
+    {
+        "Fifth.System.Functional",
+        "Fifth.System.List",
+        "Fifth.System.IO",
+        "Fifth.System.Math"
+    };
+
+    [Fact]
+    public void NoAdditionalReferences_DefaultDirectivesOnly()
+    {
+        // Validates: Requirements 4.4, 9.2, 9.3
+        var assemblyDef = CreateMinimalAssemblyDef();
+        var translator = new LoweredAstToRoslynTranslator();
+
+        var result = translator.Translate(assemblyDef, null);
+        var source = result.Sources.First();
+        var usingStatics = ExtractUsingStaticDirectives(source);
+
+        usingStatics.Should().BeEquivalentTo(DefaultUsingStatics);
+    }
+
+    [Fact]
+    public void OneReferenceWithOnePublicStaticType_AddsOneUsingStatic()
+    {
+        // Validates: Requirements 4.1, 4.2
+        var refSource = @"
+namespace CoreLib
+{
+    public static class Program
+    {
+        public static int Square(int x) => x * x;
+    }
+}";
+        var dllPath = CompileToDll(refSource);
+
+        var assemblyDef = CreateMinimalAssemblyDef();
+        var translator = new LoweredAstToRoslynTranslator();
+        var options = new TranslatorOptions
+        {
+            AdditionalReferences = new List<string> { dllPath }
+        };
+
+        var result = translator.Translate(assemblyDef, options);
+        var source = result.Sources.First();
+        var usingStatics = ExtractUsingStaticDirectives(source);
+
+        usingStatics.Should().Contain("CoreLib.Program");
+        // Should still have all defaults
+        foreach (var defaultUsing in DefaultUsingStatics)
+        {
+            usingStatics.Should().Contain(defaultUsing);
+        }
+    }
+
+    [Fact]
+    public void MultipleReferences_AddsUsingStaticForEach()
+    {
+        // Validates: Requirements 4.1, 4.2
+        var refSource1 = @"
+namespace LibA
+{
+    public static class HelperA
+    {
+        public static int Add(int a, int b) => a + b;
+    }
+}";
+        var refSource2 = @"
+namespace LibB
+{
+    public static class HelperB
+    {
+        public static int Multiply(int a, int b) => a * b;
+    }
+}";
+        var dll1 = CompileToDll(refSource1);
+        var dll2 = CompileToDll(refSource2);
+
+        var assemblyDef = CreateMinimalAssemblyDef();
+        var translator = new LoweredAstToRoslynTranslator();
+        var options = new TranslatorOptions
+        {
+            AdditionalReferences = new List<string> { dll1, dll2 }
+        };
+
+        var result = translator.Translate(assemblyDef, options);
+        var source = result.Sources.First();
+        var usingStatics = ExtractUsingStaticDirectives(source);
+
+        usingStatics.Should().Contain("LibA.HelperA");
+        usingStatics.Should().Contain("LibB.HelperB");
+    }
+
+    [Fact]
+    public void DuplicateTypeAcrossReferences_OnlyOneEmitted()
+    {
+        // Validates: Requirement 4.3
+        var sharedSource = @"
+namespace SharedNs
+{
+    public static class SharedHelper
+    {
+        public static int DoWork() => 1;
+    }
+}";
+        // Compile the same source into two separate assemblies
+        var dll1 = CompileToDll(sharedSource, "SharedAsm1");
+        var dll2 = CompileToDll(sharedSource, "SharedAsm2");
+
+        var assemblyDef = CreateMinimalAssemblyDef();
+        var translator = new LoweredAstToRoslynTranslator();
+        var options = new TranslatorOptions
+        {
+            AdditionalReferences = new List<string> { dll1, dll2 }
+        };
+
+        var result = translator.Translate(assemblyDef, options);
+        var source = result.Sources.First();
+
+        // Use the list-based extractor to detect duplicates
+        var allDirectives = ExtractAllUsingStaticDirectives(source);
+        var sharedDirectives = allDirectives.Where(d => d == "SharedNs.SharedHelper").ToList();
+
+        sharedDirectives.Should().HaveCount(1,
+            "duplicate type across assemblies should produce only one using static directive");
+    }
+}

--- a/test/ast-tests/ast_tests.csproj
+++ b/test/ast-tests/ast_tests.csproj
@@ -37,6 +37,8 @@
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="FsCheck" Version="2.16.6" />
+    <PackageReference Include="FsCheck.Xunit" Version="2.16.6" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/ast-tests/packages.lock.json
+++ b/test/ast-tests/packages.lock.json
@@ -33,6 +33,25 @@
           "System.Configuration.ConfigurationManager": "4.4.0"
         }
       },
+      "FsCheck": {
+        "type": "Direct",
+        "requested": "[2.16.6, )",
+        "resolved": "2.16.6",
+        "contentHash": "8yQlt7HgoigIXIoe7ZouNh551rypxp4WtQnqBlpB9a7gf4IkpdMSnEzsnJS/gFmeNtIf9hEJ37celeCq/6FuHA==",
+        "dependencies": {
+          "FSharp.Core": "4.2.3"
+        }
+      },
+      "FsCheck.Xunit": {
+        "type": "Direct",
+        "requested": "[2.16.6, )",
+        "resolved": "2.16.6",
+        "contentHash": "Gd8xOmsHCfi5NR3tDWTia8VGc81jgA+ca7n8RCzdPnYUlG1/WbAy2WG9PGM9DFP4ft23JeO7+9xpE/7kqujVBw==",
+        "dependencies": {
+          "FsCheck": "[2.16.6]",
+          "xunit.extensibility.execution": "[2.2.0, 3.0.0)"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[17.9.0, )",
@@ -208,6 +227,36 @@
         "contentHash": "HaI8puqA66YU7/9cK4Sgbs1taUTP1Ssa4QT2PIzqJ7GvAbN1QgkjbRsjH+FSbMh1MJdvS0CIwQNLtFT+KF6KpA==",
         "dependencies": {
           "NETStandard.Library": "1.6.1"
+        }
+      },
+      "FSharp.Core": {
+        "type": "Transitive",
+        "resolved": "4.2.3",
+        "contentHash": "PthzJd0cY9L7+mPHoMB0B9Z9moR4oO1rU5RDrVW44cfMm0R9AYFf+F3BsuTvP9clr9w/Wa0wbSfEwbJV8sV80A==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Console": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tools": "4.0.1",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.Linq.Queryable": "4.0.1",
+          "System.Net.Requests": "4.0.11",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Runtime.Numerics": "4.0.1",
+          "System.Text.RegularExpressions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11",
+          "System.Threading.Tasks.Parallel": "4.0.1",
+          "System.Threading.Thread": "4.0.0",
+          "System.Threading.ThreadPool": "4.0.10",
+          "System.Threading.Timer": "4.0.1"
         }
       },
       "HtmlAgilityPack": {
@@ -887,6 +936,21 @@
           "System.Threading": "4.3.0"
         }
       },
+      "System.Linq.Queryable": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "Yn/WfYe9RoRfmSLvUt2JerP0BTGGykCZkQPgojaxgzF2N0oPo+/AhB8TXOpdCcNlrG3VRtsamtK2uzsp3cqRVw==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Linq": "4.1.0",
+          "System.Linq.Expressions": "4.1.0",
+          "System.Reflection": "4.1.0",
+          "System.Reflection.Extensions": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0"
+        }
+      },
       "System.Net.Http": {
         "type": "Transitive",
         "resolved": "4.3.4",
@@ -931,6 +995,26 @@
           "System.Runtime.Handles": "4.3.0"
         }
       },
+      "System.Net.Requests": {
+        "type": "Transitive",
+        "resolved": "4.0.11",
+        "contentHash": "vxGt7C0cZixN+VqoSW4Yakc1Y9WknmxauDqzxgpw/FnBdz4kQNN51l4wxdXX5VY1xjqy//+G+4CvJWp1+f+y6Q==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.0.1",
+          "System.Collections": "4.0.11",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Globalization": "4.0.11",
+          "System.IO": "4.1.0",
+          "System.Net.Http": "4.1.0",
+          "System.Net.Primitives": "4.0.11",
+          "System.Net.WebHeaderCollection": "4.0.1",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
       "System.Net.Sockets": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -942,6 +1026,17 @@
           "System.Net.Primitives": "4.3.0",
           "System.Runtime": "4.3.0",
           "System.Threading.Tasks": "4.3.0"
+        }
+      },
+      "System.Net.WebHeaderCollection": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "XX2TIAN+wBSAIV51BU2FvvXMdstUa8b0FBSZmDWjZdwUMmggQSifpTOZ5fNH20z9ZCg2fkV1L5SsZnpO2RQDRQ==",
+        "dependencies": {
+          "System.Collections": "4.0.11",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0"
         }
       },
       "System.ObjectModel": {
@@ -1018,6 +1113,15 @@
         "contentHash": "ptvgrFh7PvWI8bcVqG5rsA/weWM09EnthFHR5SCnS6IN+P4mj6rE1lBDC4U8HL9/57htKAqy4KQ3bBj84cfYyQ==",
         "dependencies": {
           "System.Collections.Immutable": "8.0.0"
+        }
+      },
+      "System.Reflection.MetadataLoadContext": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "SZxrQ4sQYnIcdwiO3G/lHZopbPYQ2lW0ioT4JezgccWUrKaKbHLJbAGZaDfkYjWcta1pWssAo3MOXLsR0ie4tQ==",
+        "dependencies": {
+          "System.Collections.Immutable": "8.0.0",
+          "System.Reflection.Metadata": "8.0.0"
         }
       },
       "System.Reflection.Primitives": {
@@ -1321,12 +1425,36 @@
           "System.Threading.Tasks": "4.3.0"
         }
       },
+      "System.Threading.Tasks.Parallel": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "7Pc9t25bcynT9FpMvkUw4ZjYwUiGup/5cJFW72/5MgCG+np2cfVUMdh29u8d7onxX7d8PS3J+wL73zQRqkdrSA==",
+        "dependencies": {
+          "System.Collections.Concurrent": "4.0.12",
+          "System.Diagnostics.Debug": "4.0.11",
+          "System.Diagnostics.Tracing": "4.1.0",
+          "System.Resources.ResourceManager": "4.0.1",
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Extensions": "4.1.0",
+          "System.Threading": "4.0.11",
+          "System.Threading.Tasks": "4.0.11"
+        }
+      },
       "System.Threading.Thread": {
         "type": "Transitive",
         "resolved": "4.3.0",
         "contentHash": "OHmbT+Zz065NKII/ZHcH9XO1dEuLGI1L2k7uYss+9C1jLxTC9kTZZuzUOyXHayRk+dft9CiDf3I/QZ0t8JKyBQ==",
         "dependencies": {
           "System.Runtime": "4.3.0"
+        }
+      },
+      "System.Threading.ThreadPool": {
+        "type": "Transitive",
+        "resolved": "4.0.10",
+        "contentHash": "IMXgB5Vf/5Qw1kpoVgJMOvUO1l32aC+qC3OaIZjWJOjvcxuxNWOK2ZTWWYXfij22NHxT2j1yWX5vlAeQWld9vA==",
+        "dependencies": {
+          "System.Runtime": "4.1.0",
+          "System.Runtime.Handles": "4.0.1"
         }
       },
       "System.Threading.Timer": {
@@ -1449,6 +1577,7 @@
           "Fifth.System": "[1.0.0, )",
           "Microsoft.CodeAnalysis.CSharp": "[4.11.0, )",
           "System.CommandLine": "[2.0.0-beta4.22272.1, )",
+          "System.Reflection.MetadataLoadContext": "[8.0.0, )",
           "ast_generated": "[1.0.0, )",
           "ast_model": "[1.0.0, )",
           "parser": "[1.0.0, )"

--- a/test/language-server-smoke/packages.lock.json
+++ b/test/language-server-smoke/packages.lock.json
@@ -948,6 +948,15 @@
           "System.Collections.Immutable": "8.0.0"
         }
       },
+      "System.Reflection.MetadataLoadContext": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "SZxrQ4sQYnIcdwiO3G/lHZopbPYQ2lW0ioT4JezgccWUrKaKbHLJbAGZaDfkYjWcta1pWssAo3MOXLsR0ie4tQ==",
+        "dependencies": {
+          "System.Collections.Immutable": "8.0.0",
+          "System.Reflection.Metadata": "8.0.0"
+        }
+      },
       "System.Reflection.Primitives": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1325,6 +1334,7 @@
           "Fifth.System": "[1.0.0, )",
           "Microsoft.CodeAnalysis.CSharp": "[4.11.0, )",
           "System.CommandLine": "[2.0.0-beta4.22272.1, )",
+          "System.Reflection.MetadataLoadContext": "[8.0.0, )",
           "ast_generated": "[1.0.0, )",
           "ast_model": "[1.0.0, )",
           "parser": "[1.0.0, )"

--- a/test/runtime-integration-tests/packages.lock.json
+++ b/test/runtime-integration-tests/packages.lock.json
@@ -753,6 +753,15 @@
           "System.Runtime": "4.3.0"
         }
       },
+      "System.Reflection.MetadataLoadContext": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "SZxrQ4sQYnIcdwiO3G/lHZopbPYQ2lW0ioT4JezgccWUrKaKbHLJbAGZaDfkYjWcta1pWssAo3MOXLsR0ie4tQ==",
+        "dependencies": {
+          "System.Collections.Immutable": "8.0.0",
+          "System.Reflection.Metadata": "8.0.0"
+        }
+      },
       "System.Reflection.Primitives": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1088,6 +1097,7 @@
           "Fifth.System": "[1.0.0, )",
           "Microsoft.CodeAnalysis.CSharp": "[4.11.0, )",
           "System.CommandLine": "[2.0.0-beta4.22272.1, )",
+          "System.Reflection.MetadataLoadContext": "[8.0.0, )",
           "ast_generated": "[1.0.0, )",
           "ast_model": "[1.0.0, )",
           "parser": "[1.0.0, )"

--- a/test/syntax-parser-tests/packages.lock.json
+++ b/test/syntax-parser-tests/packages.lock.json
@@ -745,6 +745,15 @@
           "System.Collections.Immutable": "8.0.0"
         }
       },
+      "System.Reflection.MetadataLoadContext": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "SZxrQ4sQYnIcdwiO3G/lHZopbPYQ2lW0ioT4JezgccWUrKaKbHLJbAGZaDfkYjWcta1pWssAo3MOXLsR0ie4tQ==",
+        "dependencies": {
+          "System.Collections.Immutable": "8.0.0",
+          "System.Reflection.Metadata": "8.0.0"
+        }
+      },
       "System.Reflection.Primitives": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1080,6 +1089,7 @@
           "Fifth.System": "[1.0.0, )",
           "Microsoft.CodeAnalysis.CSharp": "[4.11.0, )",
           "System.CommandLine": "[2.0.0-beta4.22272.1, )",
+          "System.Reflection.MetadataLoadContext": "[8.0.0, )",
           "ast_generated": "[1.0.0, )",
           "ast_model": "[1.0.0, )",
           "parser": "[1.0.0, )"


### PR DESCRIPTION
# PR Checklist (Fifth Language Engineering Constitution)

Please confirm each item before requesting review.

- [ ] Builds the full solution without cancellation using documented commands
- [ ] Tests added/updated first and now passing locally (unit/parser/integration as applicable)
- [ ] No manual edits under `src/ast-generated/`; included metamodel/template changes and regeneration steps
- [ ] For grammar changes: visitor updates and parser tests included
- [ ] CLI behavior/contracts documented; outputs are deterministic and scriptable
- [ ] Complexity increases are justified in the description
- [ ] Versioning considered (SemVer); migration notes provided for breakages
- [ ] Docs updated (`README.md`, `AGENTS.md` references) where behavior or commands changed

## Summary
- What changed and why?
- User-visible impact (CLI, AST, grammar, codegen)?
- Alternatives considered?

## Validation
Provide commands you ran locally (paste exact output snippets as needed):

```
# Required sequence
DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet --info
java -version

dotnet restore fifthlang.sln
# Regenerate when changing AST metamodel/templates
# dotnet run --project src/ast_generator/ast_generator.csproj -- --folder src/ast-generated

dotnet build fifthlang.sln --no-restore

dotnet test test/ast-tests/ast_tests.csproj --no-build
# Optionally all tests
# dotnet test fifthlang.sln --no-build
```

## Screenshots/Logs (optional)

## Breaking Changes (if any)
- Impacted users/scenarios:
- Migration steps:

## Related Issues/Links
- 