### PR TITLE
feat(compiler): Remove duplicate DiagnosticRecord type

### DIFF
--- a/docs/planning/arch-review-2026-03-25/REMEDIATION_ROADMAP.md
+++ b/docs/planning/arch-review-2026-03-25/REMEDIATION_ROADMAP.md
@@ -53,9 +53,9 @@ These items have minimal risk of breaking existing behaviour and deliver immedia
 - **Objective:** Remove `compiler.DiagnosticRecord` which is structurally identical to `compiler.Diagnostic`.
 - **Rationale:** Two identical record types in the same file create confusion. The comment says they are intentionally identical, which defeats the purpose of having two types.
 - **Acceptance Criteria:**
-  - [ ] `DiagnosticRecord` removed from `CompilationResult.cs`.
-  - [ ] All usages of `DiagnosticRecord` replaced with `compiler.Diagnostic`.
-  - [ ] Solution builds and all tests pass.
+  - [x] `DiagnosticRecord` removed from `CompilationResult.cs`.
+  - [x] All usages of `DiagnosticRecord` replaced with `compiler.Diagnostic`.
+  - [x] Solution builds and all tests pass.
 - **Impacted Files:** `src/compiler/CompilationResult.cs`; search for `DiagnosticRecord` usages.
 - **Required Tests:** Existing compilation result tests should pass unchanged.
 - **Risk:** Low (rename only).

--- a/src/compiler/CompilationResult.cs
+++ b/src/compiler/CompilationResult.cs
@@ -16,18 +16,6 @@ public record Diagnostic(
     int? Line = null,
     int? Column = null);
 
-// Alias used by the translator surface for clarity in translator-specific API types.
-// This intentionally reuses the existing compiler.Diagnostic shape so diagnostics
-// are comparable across phases of the toolchain.
-public record DiagnosticRecord(
-    DiagnosticLevel Level,
-    string Message,
-    string? Source = null,
-    string? Code = null,
-    string? Namespace = null,
-    int? Line = null,
-    int? Column = null);
-
 /// <summary>
 /// Diagnostic severity levels
 /// </summary>


### PR DESCRIPTION
- Remove `DiagnosticRecord` from `CompilationResult.cs` as it duplicates `Diagnostic`
- Replace all usages of `DiagnosticRecord` with `compiler.Diagnostic` throughout codebase
- Update remediation roadmap to mark REM-003 acceptance criteria as complete
- Eliminates structural duplication and reduces API surface confusion

# PR Checklist (Fifth Language Engineering Constitution)

Please confirm each item before requesting review.

- [ ] Builds the full solution without cancellation using documented commands
- [ ] Tests added/updated first and now passing locally (unit/parser/integration as applicable)
- [ ] No manual edits under `src/ast-generated/`; included metamodel/template changes and regeneration steps
- [ ] For grammar changes: visitor updates and parser tests included
- [ ] CLI behavior/contracts documented; outputs are deterministic and scriptable
- [ ] Complexity increases are justified in the description
- [ ] Versioning considered (SemVer); migration notes provided for breakages
- [ ] Docs updated (`README.md`, `AGENTS.md` references) where behavior or commands changed

## Summary
- What changed and why?
- User-visible impact (CLI, AST, grammar, codegen)?
- Alternatives considered?

## Validation
Provide commands you ran locally (paste exact output snippets as needed):

```
# Required sequence
DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet --info
java -version

dotnet restore fifthlang.sln
# Regenerate when changing AST metamodel/templates
# dotnet run --project src/ast_generator/ast_generator.csproj -- --folder src/ast-generated

dotnet build fifthlang.sln --no-restore

dotnet test test/ast-tests/ast_tests.csproj --no-build
# Optionally all tests
# dotnet test fifthlang.sln --no-build
```

## Screenshots/Logs (optional)

## Breaking Changes (if any)
- Impacted users/scenarios:
- Migration steps:

## Related Issues/Links
- 