### PR TITLE
docs(arch-review): Update AS-006 remediation status with audit results

### DIFF
--- a/docs/planning/arch-review-2026-03-25/REMEDIATION_ROADMAP.md
+++ b/docs/planning/arch-review-2026-03-25/REMEDIATION_ROADMAP.md
@@ -96,9 +96,11 @@ These items have minimal risk of breaking existing behaviour and deliver immedia
 - **Objective:** Audit `ExpressionCloner.cs` and `DumpTreeVisitor.cs` — determine if they are used, document if so, or delete if dead.
 - **Rationale:** Reducing dead code improves maintainability (AS-007).
 - **Acceptance Criteria:**
-  - [ ] Each file either has a documented usage or is deleted.
-  - [ ] Solution builds and all tests pass.
-- **Impacted Files:** `src/compiler/LanguageTransformations/ExpressionCloner.cs`, `src/compiler/LanguageTransformations/DumpTreeVisitor.cs`
+  - [x] Each file either has a documented usage or is deleted.
+    - `ExpressionCloner.cs`: **Deleted** — standalone file no longer exists on disk. Expression cloning is handled by private inner classes in `AugmentedAssignmentLoweringRewriter` and `AstBuilderVisitor` where needed.
+    - `DumpTreeVisitor.cs`: **Documented** — active debugging utility used by `TreeDumpingTests.cs` and available as a commented-out diagnostic in `ParserManager.cs`. Documented in `src/ast_generator/README.md`.
+  - [x] Solution builds and all tests pass.
+- **Impacted Files:** `src/compiler/LanguageTransformations/ExpressionCloner.cs` (already deleted), `src/compiler/LanguageTransformations/DumpTreeVisitor.cs` (retained)
 - **Risk:** Low if deleted (no callers); verify with build.
 
 ---


### PR DESCRIPTION
- Mark AS-006 acceptance criteria as complete with checkbox updates
- Document ExpressionCloner.cs deletion and explain expression cloning now handled by private inner classes in AugmentedAssignmentLoweringRewriter and AstBuilderVisitor
- Document DumpTreeVisitor.cs as active debugging utility used by TreeDumpingTests.cs and ParserManager.cs, with reference to src/ast_generator/README.md
- Update impacted files list to reflect ExpressionCloner.cs deletion and DumpTreeVisitor.cs retention
- Clarify audit findings showing both files have been properly addressed per AS-007 dead code reduction objective

# PR Checklist (Fifth Language Engineering Constitution)

Please confirm each item before requesting review.

- [ ] Builds the full solution without cancellation using documented commands
- [ ] Tests added/updated first and now passing locally (unit/parser/integration as applicable)
- [ ] No manual edits under `src/ast-generated/`; included metamodel/template changes and regeneration steps
- [ ] For grammar changes: visitor updates and parser tests included
- [ ] CLI behavior/contracts documented; outputs are deterministic and scriptable
- [ ] Complexity increases are justified in the description
- [ ] Versioning considered (SemVer); migration notes provided for breakages
- [ ] Docs updated (`README.md`, `AGENTS.md` references) where behavior or commands changed

## Summary
- What changed and why?
- User-visible impact (CLI, AST, grammar, codegen)?
- Alternatives considered?

## Validation
Provide commands you ran locally (paste exact output snippets as needed):

```
# Required sequence
DOTNET_CLI_TELEMETRY_OPTOUT=1 dotnet --info
java -version

dotnet restore fifthlang.sln
# Regenerate when changing AST metamodel/templates
# dotnet run --project src/ast_generator/ast_generator.csproj -- --folder src/ast-generated

dotnet build fifthlang.sln --no-restore

dotnet test test/ast-tests/ast_tests.csproj --no-build
# Optionally all tests
# dotnet test fifthlang.sln --no-build
```

## Screenshots/Logs (optional)

## Breaking Changes (if any)
- Impacted users/scenarios:
- Migration steps:

## Related Issues/Links
- 